### PR TITLE
Device Authorization Grant Flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ erl_crash.dump
 /tmp
 .DS_Store
 /.elixir_ls
+*.swp
+.tool-versions

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,15 +1,21 @@
 use Mix.Config
 
 config :ex_oauth2_provider, namespace: Dummy
+
 config :ex_oauth2_provider, ExOauth2Provider,
-  repo: Dummy.Repo,
-  resource_owner: Dummy.Users.User,
   default_scopes: ~w(public),
+  device_flow_verification_uri: "https://test.site.net/device",
+  grant_flows: ~w(
+    authorization_code
+    client_credentials
+    device_code
+  ),
   optional_scopes: ~w(read write),
   password_auth: {Dummy.Auth, :auth},
-  use_refresh_token: true,
+  repo: Dummy.Repo,
+  resource_owner: Dummy.Users.User,
   revoke_refresh_token_on_use: true,
-  grant_flows: ~w(authorization_code client_credentials)
+  use_refresh_token: true
 
 config :ex_oauth2_provider, Dummy.Repo,
   database: "ex_oauth2_provider_test",

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -3,12 +3,13 @@ defmodule ExOauth2Provider.Config do
 
   @spec repo(keyword()) :: module()
   def repo(config) do
-    get(config, :repo) || raise """
+    get(config, :repo) ||
+      raise """
       No `:repo` found in ExOauth2Provider configuration.
 
       Please set up the repo in your configuration:
 
-      config #{inspect Keyword.get(config, :otp_app, :ex_oauth2_provider)}, ExOauth2Provider,
+      config #{inspect(Keyword.get(config, :otp_app, :ex_oauth2_provider))}, ExOauth2Provider,
         repo: MyApp.Repo
       """
   end
@@ -21,7 +22,9 @@ defmodule ExOauth2Provider.Config do
     app =
       config
       |> Keyword.get(:otp_app)
-      |> Kernel.||(raise "No `:otp_app` found in provided configuration. Please pass `:otp_app` in configuration.")
+      |> Kernel.||(
+        raise "No `:otp_app` found in provided configuration. Please pass `:otp_app` in configuration."
+      )
       |> app_base()
 
     Module.concat([app, context, module])
@@ -39,9 +42,13 @@ defmodule ExOauth2Provider.Config do
   def application(config),
     do: get_oauth_struct(config, :application)
 
+  @spec device_grant(keyword()) :: module()
+  def device_grant(config),
+    do: get_oauth_struct(config, :device_grant)
+
   defp get_oauth_struct(config, name, namespace \\ "oauth") do
     context = Macro.camelize("#{namespace}_#{name}s")
-    module  = Macro.camelize("#{namespace}_#{name}")
+    module = Macro.camelize("#{namespace}_#{name}")
 
     config
     |> get(name)
@@ -117,7 +124,7 @@ defmodule ExOauth2Provider.Config do
   # wise to keep this enabled.
   @spec force_ssl_in_redirect_uri?(keyword()) :: boolean()
   def force_ssl_in_redirect_uri?(config),
-    do: get(config, :force_ssl_in_redirect_uri, unquote(Mix.env != :dev))
+    do: get(config, :force_ssl_in_redirect_uri, unquote(Mix.env() != :dev))
 
   # Use a custom access token generator
   @spec access_token_generator(keyword()) :: {atom(), atom()} | nil
@@ -129,8 +136,47 @@ defmodule ExOauth2Provider.Config do
     do: get(config, :access_token_response_body_handler)
 
   @spec grant_flows(keyword()) :: [binary()]
-  def grant_flows(config),
-    do: get(config, :grant_flows, ~w(authorization_code client_credentials))
+  def grant_flows(config) do
+    flows = get(config, :grant_flows, ~w(authorization_code client_credentials))
+
+    case Enum.member?(flows, "device_code") do
+      # Device flow requires grant type to be this for the token request.
+      # Adding it in bound to the device code token strategy allows this to work
+      # but also allows the configuration to only need "device_code" to enable.
+      # https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
+      true -> Enum.concat(flows, ["urn:ietf:params:oauth:grant-type:device_code"])
+      false -> flows
+    end
+  end
+
+  @spec device_flow_device_code_length(keyword()) :: [integer()]
+  def device_flow_device_code_length(config),
+    do: get(config, :device_flow_device_code_length, 32)
+
+  @spec device_flow_polling_interval(keyword()) :: [integer()]
+  def device_flow_polling_interval(config),
+    do: get(config, :device_flow_polling_interval, 5)
+
+  @spec device_flow_user_code_base(keyword()) :: [integer()]
+  def device_flow_user_code_base(config),
+    do: get(config, :device_flow_user_code_base, 36)
+
+  @spec device_flow_user_code_length(keyword()) :: [integer()]
+  def device_flow_user_code_length(config),
+    do: get(config, :device_flow_user_code_length, 8)
+
+  @spec device_flow_verification_uri(keyword()) :: [binary()]
+  def device_flow_verification_uri(config),
+    do:
+      get(config, :device_flow_verification_uri) ||
+        raise("""
+        `:device_flow_verification_uri` is required to support the device flow.
+
+        Please update your configuration with the uri your application uses to verify devices:
+
+        config #{inspect(Keyword.get(config, :otp_app, :ex_oauth2_provider))}, ExOauth2Provider,
+          device_flow_verification_uri: "https://really.cool.site/device"
+        """)
 
   defp get(config, key, value \\ nil) do
     otp_app = Keyword.get(config, :otp_app)
@@ -141,18 +187,20 @@ defmodule ExOauth2Provider.Config do
     |> get_from_global_env(key)
     |> case do
       :not_found -> value
-      value      -> value
+      value -> value
     end
   end
 
   defp get_from_config(config, key), do: Keyword.get(config, key, :not_found)
 
   defp get_from_app_env(:not_found, nil, _key), do: :not_found
+
   defp get_from_app_env(:not_found, otp_app, key) do
     otp_app
     |> Application.get_env(ExOauth2Provider, [])
     |> Keyword.get(key, :not_found)
   end
+
   defp get_from_app_env(value, _otp_app, _key), do: value
 
   defp get_from_global_env(:not_found, key) do
@@ -160,5 +208,6 @@ defmodule ExOauth2Provider.Config do
     |> Application.get_env(ExOauth2Provider, [])
     |> Keyword.get(key, :not_found)
   end
+
   defp get_from_global_env(value, _key), do: value
 end

--- a/lib/ex_oauth2_provider/device_grants/device_grant.ex
+++ b/lib/ex_oauth2_provider/device_grants/device_grant.ex
@@ -1,0 +1,93 @@
+defmodule ExOauth2Provider.DeviceGrants.DeviceGrant do
+  @moduledoc """
+  Handles the Ecto schema for device grant.
+
+  ## Usage
+
+  Configure `lib/my_project/oauth_device_grants/oauth_device_grant.ex` the following way:
+
+      defmodule MyApp.OauthDeviceGrants.OauthDeviceGrant do
+        use Ecto.Schema
+        use ExOauth2Provider.DeviceGrants.DeviceGrant
+
+        schema "oauth_device_grants" do
+          device_grant_fields()
+
+          timestamps()
+        end
+      end
+  """
+
+  @type t :: Ecto.Schema.t()
+
+  @doc false
+  def attrs() do
+    [
+      {:device_code, :string, null: false},
+      {:expires_in, :integer, null: false},
+      {:last_polled_at, :utc_datetime},
+      {:scopes, :string},
+      {:user_code, :string}
+    ]
+  end
+
+  @doc false
+  def assocs() do
+    [
+      {:belongs_to, :application, :applications},
+      {:belongs_to, :resource_owner, :users}
+    ]
+  end
+
+  @doc false
+  def indexes() do
+    [
+      {:device_code, true},
+      {:user_code, true}
+    ]
+  end
+
+  defmacro __using__(config) do
+    quote do
+      use ExOauth2Provider.Schema, unquote(config)
+
+      import unquote(__MODULE__), only: [device_grant_fields: 0]
+    end
+  end
+
+  defmacro device_grant_fields do
+    quote do
+      ExOauth2Provider.Schema.fields(unquote(__MODULE__))
+    end
+  end
+
+  alias Ecto.Changeset
+  alias ExOauth2Provider.{Mixin.Scopes, Utils}
+
+  @spec changeset(Ecto.Schema.t(), map(), keyword()) :: Changeset.t()
+  def changeset(grant, params, config) do
+    grant
+    |> Changeset.cast(
+      params,
+      [
+        :device_code,
+        :expires_in,
+        :last_polled_at,
+        :resource_owner_id,
+        :scopes,
+        :user_code
+      ]
+    )
+    |> Changeset.assoc_constraint(:application)
+    |> Changeset.assoc_constraint(:resource_owner)
+    |> Scopes.put_scopes(grant.application.scopes, config)
+    |> Scopes.validate_scopes(grant.application.scopes, config)
+    |> Changeset.validate_required([
+      :device_code,
+      :expires_in,
+      :application
+    ])
+    |> Changeset.unique_constraint(:device_code)
+    |> Changeset.unique_constraint(:user_code)
+  end
+end

--- a/lib/ex_oauth2_provider/device_grants/device_grants.ex
+++ b/lib/ex_oauth2_provider/device_grants/device_grants.ex
@@ -1,0 +1,114 @@
+defmodule ExOauth2Provider.DeviceGrants do
+  @moduledoc """
+  The boundary for the OauthDeviceGrants system.
+  """
+
+  import Ecto.Query
+  alias ExOauth2Provider.Mixin.{Expirable}
+
+  alias ExOauth2Provider.{
+    Applications.Application,
+    DeviceGrants.DeviceGrant,
+    Config
+  }
+
+  defdelegate is_expired?(device_grant), to: Expirable
+
+  def authorize(device_grant, resource_owner, config) do
+    params = %{resource_owner_id: resource_owner.id, user_code: nil}
+
+    device_grant
+    |> DeviceGrant.changeset(params, config)
+    |> get_repo(config).update()
+  end
+
+  @doc """
+  Creates a device grant.
+
+  ## Examples
+
+      iex> create_grant(application, attrs)
+      {:ok, %OauthDeviceGrant{}}
+
+      iex> create_grant(application, attrs)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  @spec create_grant(Application.t(), map(), keyword()) ::
+          {:ok, DeviceGrant.t()} | {:error, term()}
+  def create_grant(application, attrs, config \\ []) do
+    {schema, repo} = schema_and_repo_from_config(config)
+
+    schema
+    |> struct(application: application)
+    |> DeviceGrant.changeset(attrs, config)
+    |> repo.insert()
+  end
+
+  def delete_expired(config) do
+    {schema, repo} = schema_and_repo_from_config(config)
+    lifespan = Config.authorization_code_expires_in(config)
+
+    from(
+      d in schema,
+      where: d.inserted_at <= ago(^lifespan, "second")
+    )
+    |> repo.delete_all()
+  end
+
+  def delete!(grant, config) do
+    get_repo(config).delete!(grant)
+  end
+
+  @doc """
+  Gets a single device grant registered with an application.
+
+  ## Examples
+
+      iex> find_by_application_and_device_code(application, "jE9dk", otp_app: :my_app)
+      %OauthDeviceGrant{}
+
+      iex> find_by_application_and_device_code(application, "jE9dk", otp_app: :my_app)
+      ** nil
+
+  """
+  @spec find_by_application_and_device_code(Application.t(), binary(), keyword()) ::
+          DeviceGrant.t() | nil
+  def find_by_application_and_device_code(application, device_code, config \\ []) do
+    {schema, repo} = schema_and_repo_from_config(config)
+    repo.get_by(schema, application_id: application.id, device_code: device_code)
+  end
+
+  def find_by_user_code(nil, _config), do: nil
+
+  # DeviceGrant | nil
+  def find_by_user_code(user_code, config) do
+    config
+    |> schema_and_repo_from_config()
+    |> fetch_grant_with_user_code(user_code)
+  end
+
+  def update_last_polled_at!(grant, config) do
+    grant
+    |> DeviceGrant.changeset(%{last_polled_at: DateTime.utc_now()}, config)
+    |> get_repo(config).update!()
+  end
+
+  defp device_grant_schema(config), do: Config.device_grant(config)
+
+  defp fetch_grant_with_user_code({schema, repo}, user_code) do
+    # from(d in schema, preload: [:application], where: d.user_code == ^user_code)
+    schema
+    |> repo.get_by(user_code: user_code)
+    |> repo.preload(:application)
+  end
+
+  defp get_repo(config), do: Config.repo(config)
+
+  defp schema_and_repo_from_config(config) do
+    {
+      Config.device_grant(config),
+      Config.repo(config)
+    }
+  end
+end

--- a/lib/ex_oauth2_provider/oauth2/authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization.ex
@@ -6,30 +6,44 @@ defmodule ExOauth2Provider.Authorization do
     Authorization.Utils,
     Authorization.Utils.Response,
     Config,
-    Utils.Error}
+    Utils.Error
+  }
+
   alias Ecto.Schema
 
   @doc """
   Check ExOauth2Provider.Authorization.Code for usage.
   """
-  @spec preauthorize(Schema.t(), map(), keyword()) :: Response.success() | Response.error() | Response.redirect() | Response.native_redirect()
+  @spec preauthorize(Schema.t(), map(), keyword()) ::
+          Response.success() | Response.error() | Response.redirect() | Response.native_redirect()
   def preauthorize(resource_owner, request, config \\ []) do
     case validate_response_type(request, config) do
-      {:error, :invalid_response_type} -> unsupported_response_type(resource_owner, request, config)
-      {:error, :missing_response_type} -> invalid_request(resource_owner, request, config)
-      {:ok, token_module}              -> token_module.preauthorize(resource_owner, request, config)
+      {:error, :invalid_response_type} ->
+        unsupported_response_type(resource_owner, request, config)
+
+      {:error, :missing_response_type} ->
+        invalid_request(resource_owner, request, config)
+
+      {:ok, token_module} ->
+        token_module.preauthorize(resource_owner, request, config)
     end
   end
 
   @doc """
   Check ExOauth2Provider.Authorization.Code for usage.
   """
-  @spec authorize(Schema.t(), map(), keyword()) :: {:ok, binary()} | Response.error() | Response.redirect() | Response.native_redirect()
+  @spec authorize(Schema.t(), map(), keyword()) ::
+          {:ok, binary()} | Response.error() | Response.redirect() | Response.native_redirect()
   def authorize(resource_owner, request, config \\ []) do
     case validate_response_type(request, config) do
-      {:error, :invalid_response_type} -> unsupported_response_type(resource_owner, request, config)
-      {:error, :missing_response_type} -> invalid_request(resource_owner, request, config)
-      {:ok, token_module}              -> token_module.authorize(resource_owner, request, config)
+      {:error, :invalid_response_type} ->
+        unsupported_response_type(resource_owner, request, config)
+
+      {:error, :missing_response_type} ->
+        invalid_request(resource_owner, request, config)
+
+      {:ok, token_module} ->
+        token_module.authorize(resource_owner, request, config)
     end
   end
 
@@ -39,9 +53,14 @@ defmodule ExOauth2Provider.Authorization do
   @spec deny(Schema.t(), map(), keyword()) :: Response.error() | Response.redirect()
   def deny(resource_owner, request, config \\ []) do
     case validate_response_type(request, config) do
-      {:error, :invalid_response_type} -> unsupported_response_type(resource_owner, request, config)
-      {:error, :missing_response_type} -> invalid_request(resource_owner, request, config)
-      {:ok, token_module}              -> token_module.deny(resource_owner, request, config)
+      {:error, :invalid_response_type} ->
+        unsupported_response_type(resource_owner, request, config)
+
+      {:error, :missing_response_type} ->
+        invalid_request(resource_owner, request, config)
+
+      {:ok, token_module} ->
+        token_module.deny(resource_owner, request, config)
     end
   end
 
@@ -67,9 +86,11 @@ defmodule ExOauth2Provider.Authorization do
       mod -> {:ok, mod}
     end
   end
+
   defp validate_response_type(_, _config), do: {:error, :missing_response_type}
 
   defp response_type_to_grant_flow("code"), do: "authorization_code"
+  defp response_type_to_grant_flow("device_code"), do: "device_code"
   defp response_type_to_grant_flow(_), do: nil
 
   defp fetch_module(grant_flow, config) do
@@ -77,7 +98,7 @@ defmodule ExOauth2Provider.Authorization do
     |> Config.grant_flows()
     |> flow_can_be_used?(grant_flow)
     |> case do
-      true  -> flow_to_mod(grant_flow)
+      true -> flow_to_mod(grant_flow)
       false -> nil
     end
   end
@@ -87,5 +108,6 @@ defmodule ExOauth2Provider.Authorization do
   end
 
   defp flow_to_mod("authorization_code"), do: ExOauth2Provider.Authorization.Code
+  defp flow_to_mod("device_code"), do: ExOauth2Provider.Authorization.DeviceCode
   defp flow_to_mod(_), do: nil
 end

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code.ex
@@ -1,0 +1,20 @@
+defmodule ExOauth2Provider.Authorization.DeviceCode do
+  alias ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization
+  alias ExOauth2Provider.Authorization.DeviceCode.UserInteraction
+
+  # NOTE: This module is the glue for the various steps and integrates it into
+  # the authorization architecture that this package provides. It separates
+  # the concerns to simplify things.
+
+  # User Interaction Request - approve the grant with user code
+  # https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+  def authorize(resource_owner, request, config \\ []) do
+    UserInteraction.process_request(resource_owner, request, config)
+  end
+
+  # Device Authorization Request
+  # https://tools.ietf.org/html/rfc8628#section-3.1
+  def preauthorize(_resource_owner, request, config \\ []) do
+    DeviceAuthorization.process_request(request, config)
+  end
+end

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
@@ -1,0 +1,88 @@
+defmodule ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization do
+  alias ExOauth2Provider.{
+    Config,
+    DeviceGrants,
+    Authorization.Utils,
+    Scopes,
+    Utils.DeviceFlow,
+    Utils.Error,
+    Utils.Validation
+  }
+
+  @required_params ~w(client_id)
+
+  # Device Authorization Request
+  # https://tools.ietf.org/html/rfc8628#section-3.1
+  def process_request(request, config \\ []) do
+    %{config: config, request: request}
+    |> Validation.validate_required_query_params(@required_params)
+    |> load_application()
+    |> Validation.validate_scope()
+    |> issue_grant()
+    |> send_response()
+  end
+
+  def send_response({:ok, %{config: config, grant: grant}}) do
+    payload = %{
+      device_code: grant.device_code,
+      expires_in: grant.expires_in,
+      interval: Config.device_flow_polling_interval(config),
+      user_code: grant.user_code,
+      verification_uri: Config.device_flow_verification_uri(config)
+    }
+
+    {:ok, payload}
+  end
+
+  def send_response({:error, %{error: error, error_http_status: http_status}}) do
+    {:error, error, http_status}
+  end
+
+  def send_response({:error, error, http_status}) do
+    {:error, error, http_status}
+  end
+
+  defp generate_grant_params(request, config) do
+    %{
+      device_code: DeviceFlow.generate_device_code(),
+      expires_in: Config.authorization_code_expires_in(config),
+      scopes: Map.get(request, "scope"),
+      user_code: DeviceFlow.generate_user_code()
+    }
+  end
+
+  defp issue_grant({:ok, context}) do
+    %{client: application, config: config, request: request} = context
+
+    # This is just basic cleanup.
+    DeviceGrants.delete_expired(config)
+
+    grant_params = generate_grant_params(request, config)
+
+    case DeviceGrants.create_grant(application, grant_params, config) do
+      {:ok, grant} -> {:ok, Map.put(context, :grant, grant)}
+      {:error, error} -> Error.add_error({:ok, context}, error)
+    end
+  end
+
+  defp issue_grant(error_response), do: error_response
+
+  defp load_application({:ok, %{config: config, request: request}}) do
+    # There is no resource owner on this request so we explicitly pass nil.
+    # This pre-handler is constructing a new map based on request so we need
+    # to stitch back in config. Since we pre-validate the required params
+    # and have a context before this runs it's easier this way until it can be
+    # refactored to work on a pre-made context.
+    {ok_or_error, context} =
+      Utils.prehandle_request(
+        nil,
+        request,
+        config,
+        error_http_status: :unauthorized
+      )
+
+    {ok_or_error, Map.put(context, :config, config)}
+  end
+
+  defp load_application(error_response), do: error_response
+end

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction.ex
@@ -1,0 +1,60 @@
+defmodule ExOauth2Provider.Authorization.DeviceCode.UserInteraction do
+  alias Ecto.Changeset
+  alias ExOauth2Provider.DeviceGrants
+
+  @message_lookup [
+    expired_user_code: "The user_code has expired.",
+    invalid_owner: "The given owner is invalid.",
+    invalid_user_code: "The user_code is invalid.",
+    user_code_missing: "The request is missing the required param user_code."
+  ]
+  @status_lookup [
+    expired_user_code: :unprocessable_entity,
+    invalid_owner: :unprocessable_entity,
+    invalid_user_code: :unprocessable_entity,
+    user_code_missing: :bad_request
+  ]
+
+  # User Interaction Request - approve the grant with user code
+  # https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+  def process_request(owner, request, config \\ []) do
+    %{config: config, owner: owner, user_code: Map.get(request, "user_code")}
+    |> find_device_grant()
+    |> authorize()
+    |> send_response()
+  end
+
+  defp authorize({:error, _code} = error), do: error
+  defp authorize(%{grant: nil}), do: {:error, :invalid_user_code}
+
+  defp authorize(%{config: config, grant: grant, owner: owner}) do
+    if DeviceGrants.is_expired?(grant) do
+      {:error, :expired_user_code}
+    else
+      DeviceGrants.authorize(grant, owner, config)
+    end
+  end
+
+  defp find_device_grant(%{user_code: nil}) do
+    {:error, :user_code_missing}
+  end
+
+  defp find_device_grant(%{config: config, user_code: user_code} = context) do
+    Map.put(context, :grant, DeviceGrants.find_by_user_code(user_code, config))
+  end
+
+  defp send_response({:error, %Changeset{}}) do
+    send_response({:error, :invalid_owner})
+  end
+
+  defp send_response({:error, code}) do
+    message = Keyword.get(@message_lookup, code)
+    status = Keyword.get(@status_lookup, code)
+
+    {:error, %{error: code, error_description: message}, status}
+  end
+
+  defp send_response({:ok, device_grant}) do
+    {:ok, device_grant}
+  end
+end

--- a/lib/ex_oauth2_provider/oauth2/authorization/utils.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/utils.ex
@@ -6,10 +6,10 @@ defmodule ExOauth2Provider.Authorization.Utils do
 
   @doc false
   @spec prehandle_request(Schema.t(), map(), keyword()) :: {:ok, map()} | {:error, map()}
-  def prehandle_request(resource_owner, request, config) do
+  def prehandle_request(resource_owner, request, config, opts \\ []) do
     resource_owner
     |> new_params(request)
-    |> load_client(config)
+    |> load_client(config, opts)
     |> set_defaults()
   end
 
@@ -17,22 +17,26 @@ defmodule ExOauth2Provider.Authorization.Utils do
     {:ok, %{resource_owner: resource_owner, request: request}}
   end
 
-  defp load_client({:ok, %{request: %{"client_id" => client_id}} = params}, config) do
+  defp load_client({:ok, %{request: %{"client_id" => client_id}} = params}, config, opts) do
     case Applications.get_application(client_id, config) do
-      nil    -> Error.add_error({:ok, params}, Error.invalid_client())
+      nil -> Error.add_error({:ok, params}, Error.invalid_client(opts))
       client -> {:ok, Map.put(params, :client, client)}
     end
   end
-  defp load_client({:ok, params}, _config), do: Error.add_error({:ok, params}, Error.invalid_request())
+
+  defp load_client({:ok, params}, _config, _opts),
+    do: Error.add_error({:ok, params}, Error.invalid_request())
 
   defp set_defaults({:error, params}), do: {:error, params}
+
   defp set_defaults({:ok, %{request: request, client: client} = params}) do
     [redirect_uri | _rest] = String.split(client.redirect_uri)
 
-    request = Map.new()
-    |> Map.put("redirect_uri", redirect_uri)
-    |> Map.put("scope", nil)
-    |> Map.merge(request)
+    request =
+      Map.new()
+      |> Map.put("redirect_uri", redirect_uri)
+      |> Map.put("scope", nil)
+      |> Map.merge(request)
 
     {:ok, Map.put(params, :request, request)}
   end

--- a/lib/ex_oauth2_provider/oauth2/token.ex
+++ b/lib/ex_oauth2_provider/oauth2/token.ex
@@ -5,7 +5,9 @@ defmodule ExOauth2Provider.Token do
   alias ExOauth2Provider.{
     Config,
     Token.Revoke,
-    Utils.Error}
+    Utils.Error
+  }
+
   alias Ecto.Schema
 
   @doc """
@@ -28,7 +30,7 @@ defmodule ExOauth2Provider.Token do
     case validate_grant_type(request, config) do
       {:error, :invalid_grant_type} -> Error.unsupported_grant_type()
       {:error, :missing_grant_type} -> Error.invalid_request()
-      {:ok, token_module}           -> token_module.grant(request, config)
+      {:ok, token_module} -> token_module.grant(request, config)
     end
   end
 
@@ -40,6 +42,7 @@ defmodule ExOauth2Provider.Token do
       mod -> {:ok, mod}
     end
   end
+
   defp validate_grant_type(_, _config), do: {:error, :missing_grant_type}
 
   defp fetch_module(type, config) do
@@ -47,15 +50,17 @@ defmodule ExOauth2Provider.Token do
     |> Config.grant_flows()
     |> grant_type_can_be_used?(type, config)
     |> case do
-      true  -> grant_type_to_mod(type)
+      true -> grant_type_to_mod(type)
       false -> nil
     end
   end
 
   defp grant_type_can_be_used?(_, "refresh_token", config),
     do: Config.use_refresh_token?(config)
+
   defp grant_type_can_be_used?(_, "password", config),
     do: not is_nil(Config.password_auth(config))
+
   defp grant_type_can_be_used?(grant_flows, grant_type, _config) do
     Enum.member?(grant_flows, grant_type)
   end
@@ -64,6 +69,10 @@ defmodule ExOauth2Provider.Token do
   defp grant_type_to_mod("client_credentials"), do: ExOauth2Provider.Token.ClientCredentials
   defp grant_type_to_mod("password"), do: ExOauth2Provider.Token.Password
   defp grant_type_to_mod("refresh_token"), do: ExOauth2Provider.Token.RefreshToken
+
+  defp grant_type_to_mod("urn:ietf:params:oauth:grant-type:device_code"),
+    do: ExOauth2Provider.Token.DeviceCode
+
   defp grant_type_to_mod(_), do: nil
 
   @doc """

--- a/lib/ex_oauth2_provider/oauth2/token/strategy/device_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/strategy/device_code.ex
@@ -1,0 +1,151 @@
+defmodule ExOauth2Provider.Token.DeviceCode do
+  alias ExOauth2Provider.{AccessTokens, Config, DeviceGrants}
+  alias ExOauth2Provider.Token.Utils
+  alias ExOauth2Provider.Utils.{Error, Validation}
+
+  @required_params ~w(client_id device_code)
+
+  # Device Access Token Request
+  # https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
+  #
+  # NOTE: http error status for invalid_client in a token response  should be
+  # 401, not 422 which is the value provided in Error#invalid_client.
+  # This overrides that so we get the expected behavior.
+  # https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+  def grant(request, config \\ []) do
+    %{config: config, request: request}
+    |> Validation.validate_required_query_params(@required_params)
+    |> Utils.load_client(config, error_http_status: :unauthorized)
+    |> Validation.validate_scope()
+    |> load_grant()
+    |> check_expiration()
+    |> check_polling_rate()
+    |> check_authorization()
+    |> create_token()
+    |> send_response()
+  end
+
+  defp send_response({:ok, %{access_token: access_token}}) do
+    {
+      :ok,
+      %{
+        access_token: access_token.token,
+        expires: access_token.expires_in,
+        refresh_token: access_token.refresh_token,
+        scope: access_token.scopes,
+        token_type: "bearer"
+      }
+    }
+  end
+
+  defp send_response(error_response), do: error_response
+
+  defp create_token({:ok, context}) do
+    %{config: config, grant: grant} = context
+
+    result =
+      Config.repo(config).transaction(fn ->
+        grant
+        |> DeviceGrants.delete!(config)
+        |> find_or_create_token(context)
+      end)
+
+    case result do
+      {:ok, {:error, error}} -> Error.add_error({:ok, context}, error)
+      {:ok, {:ok, access_token}} -> {:ok, Map.put(context, :access_token, access_token)}
+      {:error, error} -> Error.add_error({:ok, context}, error)
+    end
+  end
+
+  defp create_token(error_response), do: error_response
+
+  defp check_authorization({:ok, %{grant: %{user_code: nil}} = context}) do
+    {:ok, context}
+  end
+
+  defp check_authorization({:ok, %{grant: %{user_code: _user_code}}}) do
+    {:error, %{error: :authorization_pending}, :bad_request}
+  end
+
+  defp check_authorization(error_response), do: error_response
+
+  defp check_expiration({:ok, %{config: config, grant: grant} = context}) do
+    too_old =
+      DateTime.utc_now()
+      |> DateTime.add(-grant.expires_in, :second)
+      |> DateTime.truncate(:second)
+
+    inserted_at = DateTime.from_naive!(grant.inserted_at, "Etc/UTC")
+
+    case inserted_at > too_old do
+      false ->
+        DeviceGrants.delete!(grant, config)
+        {:error, %{error: :expired_token}, :bad_request}
+
+      true ->
+        {:ok, context}
+    end
+  end
+
+  defp check_expiration(error_response), do: error_response
+
+  defp check_polling_rate({:ok, %{config: config, grant: grant} = context}) do
+    # NOTE: The DeviceGrant struct has seconds precision.
+    age_limit =
+      DateTime.utc_now()
+      |> DateTime.add(-Config.device_flow_polling_interval(config), :second)
+      |> DateTime.truncate(:second)
+
+    too_fast = grant.last_polled_at && grant.last_polled_at >= age_limit
+
+    DeviceGrants.update_last_polled_at!(grant, config)
+
+    case too_fast do
+      true -> {:error, %{error: :slow_down}, :bad_request}
+      nil -> {:ok, context}
+      false -> {:ok, context}
+    end
+  end
+
+  defp check_polling_rate(error_response), do: error_response
+
+  defp find_or_create_token(deleted_grant, context) do
+    %{client: application, config: config, request: request} = context
+    scopes = Map.get(request, "scope", nil)
+
+    token_params = %{
+      application: application,
+      scopes: scopes,
+      use_refresh_token: Config.use_refresh_token?(config)
+    }
+
+    deleted_grant.resource_owner
+    |> AccessTokens.get_token_for(application, scopes, config)
+    |> case do
+      nil -> AccessTokens.create_token(deleted_grant.resource_owner, token_params, config)
+      access_token -> {:ok, access_token}
+    end
+  end
+
+  defp load_grant({:ok, context}) do
+    %{client: client, config: config, request: request} = context
+    device_code = Map.get(request, "device_code")
+
+    client
+    |> DeviceGrants.find_by_application_and_device_code(device_code, config)
+    |> Config.repo(config).preload(:application)
+    |> Config.repo(config).preload(:resource_owner)
+    |> case do
+      nil -> Error.invalid_grant(:bad_request)
+      grant -> {:ok, Map.put(context, :grant, grant)}
+    end
+  end
+
+  # NOTE: This is from Utils.load_client failure.
+  # It joins the status to the context.
+  defp load_grant({:error, %{error: error, error_http_status: status}}) do
+    {:error, error, status}
+  end
+
+  defp load_grant({:error, error, status}), do: {:error, error, status}
+end

--- a/lib/ex_oauth2_provider/oauth2/token/utils.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/utils.ex
@@ -5,14 +5,22 @@ defmodule ExOauth2Provider.Token.Utils do
 
   @doc false
   @spec load_client({:ok, map()}, keyword()) :: {:ok, map()} | {:error, map()}
-  def load_client({:ok, %{request: request = %{"client_id" => client_id}} = params}, config) do
+  def load_client(
+        {:ok, %{request: request = %{"client_id" => client_id}} = params},
+        config,
+        opts \\ []
+      ) do
     client_secret = Map.get(request, "client_secret", "")
 
     case Applications.load_application(client_id, client_secret, config) do
-      nil    -> Error.add_error({:ok, params}, Error.invalid_client())
+      nil -> Error.add_error({:ok, params}, Error.invalid_client(opts))
       client -> {:ok, Map.merge(params, %{client: client})}
     end
   end
-  def load_client({:ok, params}, _config), do: Error.add_error({:ok, params}, Error.invalid_request())
-  def load_client({:error, params}, _config), do: {:error, params}
+
+  def load_client({:ok, params}, _config, _ops),
+    do: Error.add_error({:ok, params}, Error.invalid_request())
+
+  def load_client({:error, params}, _config, _opts), do: {:error, params}
+  def load_client({:error, params, status}, _config, _opts), do: {:error, params, status}
 end

--- a/lib/ex_oauth2_provider/oauth2/utils/device_flow.ex
+++ b/lib/ex_oauth2_provider/oauth2/utils/device_flow.ex
@@ -1,0 +1,26 @@
+defmodule ExOauth2Provider.Utils.DeviceFlow do
+  alias ExOauth2Provider.Config
+
+  def generate_device_code(config \\ [otp_app: :ex_oauth2_provider]) do
+    config
+    |> Config.device_flow_device_code_length()
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64()
+  end
+
+  def generate_user_code(config \\ [otp_app: :ex_oauth2_provider]) do
+    # NOTE: Integer.pow only exists in elixir 1.12+
+    # So we have to convert erlangs pow response to integer
+    # Thanks to Doorkeeper for this!
+    max_length = Config.device_flow_user_code_length(config)
+    base = Config.device_flow_user_code_base(config)
+
+    base
+    |> :math.pow(max_length)
+    |> trunc()
+    |> :rand.uniform()
+    |> Integer.to_string(base)
+    |> String.upcase()
+    |> String.pad_leading(max_length, "0")
+  end
+end

--- a/lib/ex_oauth2_provider/oauth2/utils/error.ex
+++ b/lib/ex_oauth2_provider/oauth2/utils/error.ex
@@ -4,35 +4,47 @@ defmodule ExOauth2Provider.Utils.Error do
   @doc false
   @spec add_error({:ok, map()} | {:error, map()}, {:error, map(), atom()}) :: {:error, map()}
   def add_error({:error, params}, _), do: {:error, params}
+
   def add_error({:ok, params}, {:error, error, http_status}) do
     {:error, Map.merge(params, %{error: error, error_http_status: http_status})}
   end
 
   @spec server_error() :: {:error, map(), atom()}
   def server_error do
-    msg = "The authorization server encountered an unexpected condition which prevented it from fulfilling the request."
+    msg =
+      "The authorization server encountered an unexpected condition which prevented it from fulfilling the request."
+
     {:error, %{error: :internal_server_error, error_description: msg}, :internal_server_error}
   end
 
   @doc false
   @spec invalid_request() :: {:error, map(), atom()}
-  def invalid_request do
-    msg = "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
+  def invalid_request(msg \\ nil) do
+    msg =
+      msg ||
+        "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
+
     {:error, %{error: :invalid_request, error_description: msg}, :bad_request}
   end
 
   @doc false
   @spec invalid_client() :: {:error, map(), atom()}
-  def invalid_client do
-    msg = "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
-    {:error, %{error: :invalid_client, error_description: msg}, :unprocessable_entity}
+  def invalid_client(options \\ []) do
+    status = Keyword.get(options, :error_http_status, :unprocessable_entity)
+
+    msg =
+      "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
+
+    {:error, %{error: :invalid_client, error_description: msg}, status}
   end
 
   @doc false
   @spec invalid_grant() :: {:error, map(), atom()}
-  def invalid_grant do
-    msg = "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
-    {:error, %{error: :invalid_grant, error_description: msg}, :unprocessable_entity}
+  def invalid_grant(status \\ :unprocessable_entity) do
+    msg =
+      "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+
+    {:error, %{error: :invalid_grant, error_description: msg}, status}
   end
 
   @doc false
@@ -44,9 +56,9 @@ defmodule ExOauth2Provider.Utils.Error do
 
   @doc false
   @spec invalid_scopes() :: {:error, map(), atom()}
-  def invalid_scopes do
+  def invalid_scopes(status \\ :unprocessable_entity) do
     msg = "The requested scope is invalid, unknown, or malformed."
-    {:error, %{error: :invalid_scope, error_description: msg}, :unprocessable_entity}
+    {:error, %{error: :invalid_scope, error_description: msg}, status}
   end
 
   @doc false

--- a/lib/ex_oauth2_provider/oauth2/utils/validation.ex
+++ b/lib/ex_oauth2_provider/oauth2/utils/validation.ex
@@ -1,0 +1,60 @@
+defmodule ExOauth2Provider.Utils.Validation do
+  alias ExOauth2Provider.Scopes
+  alias ExOauth2Provider.Utils.Error
+
+  def validate_request({:ok, %{request: %{"scope" => scopes}, client: client} = params}, config) do
+    scopes = Scopes.to_list(scopes)
+
+    server_scopes =
+      client.scopes
+      |> Scopes.to_list()
+      |> Scopes.default_to_server_scopes(config)
+
+    case Scopes.all?(server_scopes, scopes) do
+      true -> {:ok, params}
+      false -> Error.add_error({:ok, params}, Error.invalid_scopes())
+    end
+  end
+
+  def validate_request(error_response, _config), do: error_response
+
+  def validate_required_query_params(%{request: request} = context, param_names) do
+    missing =
+      Enum.reject(
+        param_names,
+        fn name -> name in Map.keys(request) end
+      )
+
+    case missing do
+      [] ->
+        {:ok, context}
+
+      missing ->
+        Error.invalid_request("Missing required param #{Enum.join(missing, ", ")}")
+    end
+  end
+
+  # This can't be included in the required params because it simply checks
+  # presence and is done before you try to load any records. This requires
+  # the client_id and the record to be loaded already.
+  def validate_scope({:ok, context}) do
+    %{client: application, config: config, request: request} = context
+
+    scopes =
+      request
+      |> Map.get("scope")
+      |> Scopes.to_list()
+
+    server_scopes =
+      application.scopes
+      |> Scopes.to_list()
+      |> Scopes.default_to_server_scopes(config)
+
+    case Scopes.all?(server_scopes, scopes) do
+      true -> {:ok, context}
+      false -> Error.invalid_scopes(:bad_request)
+    end
+  end
+
+  def validate_scope(error_response), do: error_response
+end

--- a/lib/mix/ex_oauth2_provider/migration.ex
+++ b/lib/mix/ex_oauth2_provider/migration.ex
@@ -10,11 +10,13 @@ defmodule Mix.ExOauth2Provider.Migration do
   @spec create_migration_file(atom(), binary(), binary()) :: any()
   def create_migration_file(repo, name, content) do
     base_name = "#{Macro.underscore(name)}.exs"
-    path      =
+
+    path =
       repo
       |> Mix.EctoSQL.source_repo_priv()
       |> Path.join("migrations")
       |> maybe_create_directory()
+
     timestamp = timestamp(path)
 
     path
@@ -34,8 +36,13 @@ defmodule Mix.ExOauth2Provider.Migration do
     |> Path.join("*_#{base_name}")
     |> Path.wildcard()
     |> case do
-      [] -> path
-      _  -> Mix.raise("migration can't be created, there is already a migration file with name #{name}.")
+      [] ->
+        path
+
+      _ ->
+        Mix.raise(
+          "migration can't be created, there is already a migration file with name #{name}."
+        )
     end
   end
 
@@ -47,7 +54,7 @@ defmodule Mix.ExOauth2Provider.Migration do
     |> Path.wildcard()
     |> case do
       [] -> timestamp
-      _  -> timestamp(path, seconds + 1)
+      _ -> timestamp(path, seconds + 1)
     end
   end
 
@@ -61,7 +68,7 @@ defmodule Mix.ExOauth2Provider.Migration do
     "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
   end
 
-  defp pad(i) when i < 10, do: << ?0, ?0 + i >>
+  defp pad(i) when i < 10, do: <<?0, ?0 + i>>
   defp pad(i), do: to_string(i)
 
   @template """
@@ -84,28 +91,49 @@ defmodule Mix.ExOauth2Provider.Migration do
   end
   """
 
-  alias ExOauth2Provider.{AccessGrants.AccessGrant, AccessTokens.AccessToken, Applications.Application}
+  alias ExOauth2Provider.{
+    AccessGrants.AccessGrant,
+    AccessTokens.AccessToken,
+    Applications.Application,
+    DeviceGrants.DeviceGrant
+  }
 
-  @schemas [{"applications", Application}, {"access_grants", AccessGrant}, {"access_tokens", AccessToken}]
+  @required_schemas [
+    {"applications", Application},
+    {"access_grants", AccessGrant},
+    {"access_tokens", AccessToken}
+  ]
+  @optional_schemas %{device_grants: {"device_grants", DeviceGrant}}
 
   @spec gen(binary(), binary(), map()) :: binary()
   def gen(name, namespace, %{repo: repo} = config) do
+    schemas = @required_schemas ++ with_device_grants(config)
+
     schemas =
-      for {table, module} <- @schemas,
-        do: schema(module, table, namespace, config)
+      for {table, module} <- schemas,
+          do: schema(module, table, namespace, config)
 
     EEx.eval_string(@template, migration: %{repo: repo, name: name, schemas: schemas})
   end
 
+  defp with_device_grants(%{device_code: device_code} = _config) when device_code == true do
+    [Map.get(@optional_schemas, :device_grants)]
+  end
+
+  defp with_device_grants(_config) do
+    []
+  end
+
   defp schema(module, table, namespace, %{binary_id: binary_id}) do
-    attrs           =
+    attrs =
       module.attrs()
       |> Kernel.++(attrs_from_assocs(module.assocs(), namespace))
       |> migration_attrs()
-    defaults        = defaults(attrs)
+
+    defaults = defaults(attrs)
     {assocs, attrs} = partition_attrs(attrs)
-    table           = "#{namespace}_#{table}"
-    indexes         = migration_indexes(module.indexes(), table)
+    table = "#{namespace}_#{table}"
+    indexes = migration_indexes(module.indexes(), table)
 
     %{
       table: table,
@@ -126,10 +154,14 @@ defmodule Mix.ExOauth2Provider.Migration do
   defp attr_from_assoc({:belongs_to, name, :users}, _namespace) do
     {String.to_atom("#{name}_id"), {:references, :users}}
   end
+
   defp attr_from_assoc({:belongs_to, name, table}, namespace) do
     {String.to_atom("#{name}_id"), {:references, String.to_atom("#{namespace}_#{table}")}}
   end
-  defp attr_from_assoc({:belongs_to, name, table, _defaults}, namespace), do: attr_from_assoc({:belongs_to, name, table}, namespace)
+
+  defp attr_from_assoc({:belongs_to, name, table, _defaults}, namespace),
+    do: attr_from_assoc({:belongs_to, name, table}, namespace)
+
   defp attr_from_assoc(_assoc, _opts), do: nil
 
   defp migration_attrs(attrs) do
@@ -139,11 +171,13 @@ defmodule Mix.ExOauth2Provider.Migration do
   defp to_migration_attr({name, type}) do
     {name, type, ""}
   end
+
   defp to_migration_attr({name, type, []}) do
     to_migration_attr({name, type})
   end
+
   defp to_migration_attr({name, type, defaults}) do
-    defaults = Enum.map_join(defaults, ", ", fn {k, v} -> "#{k}: #{inspect v}" end)
+    defaults = Enum.map_join(defaults, ", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
 
     {name, type, ", #{defaults}"}
   end
@@ -161,7 +195,8 @@ defmodule Mix.ExOauth2Provider.Migration do
         _ -> false
       end)
 
-    attrs  = Enum.map(attrs, fn {key_id, type, _defaults} -> {key_id, type} end)
+    attrs = Enum.map(attrs, fn {key_id, type, _defaults} -> {key_id, type} end)
+
     assocs =
       Enum.map(assocs, fn {key_id, {:references, source}, _} ->
         key = String.replace(Atom.to_string(key_id), "_id", "")

--- a/lib/mix/ex_oauth2_provider/schema.ex
+++ b/lib/mix/ex_oauth2_provider/schema.ex
@@ -19,24 +19,57 @@ defmodule Mix.ExOauth2Provider.Schema do
   end
   """
 
-  alias ExOauth2Provider.{AccessGrants.AccessGrant, AccessTokens.AccessToken, Applications.Application}
+  alias ExOauth2Provider.{
+    AccessGrants.AccessGrant,
+    AccessTokens.AccessToken,
+    Applications.Application,
+    DeviceGrants.DeviceGrant
+  }
 
-  @schemas [{"application", Application}, {"access_grant", AccessGrant}, {"access_token", AccessToken}]
+  @required_schemas [
+    {"application", Application},
+    {"access_grant", AccessGrant},
+    {"access_token", AccessToken}
+  ]
+  @optional_schemas [
+    {"device_grant", DeviceGrant}
+  ]
 
   @spec create_schema_files(atom(), binary(), keyword()) :: any()
   def create_schema_files(context_app, namespace, opts) do
-    for {table, schema} <- @schemas do
-      app_base     = Config.app_base(context_app)
-      table_name   = "#{namespace}_#{table}s"
-      context      = Macro.camelize(table_name)
-      module       = Macro.camelize("#{namespace}_#{table}")
-      file         = "#{Macro.underscore(module)}.ex"
-      module       = Module.concat([app_base, context, module])
-      binary_id    = Keyword.get(opts, :binary_id, false)
-      macro        = schema
+    app_base = Config.app_base(context_app)
+    binary_id = Keyword.get(opts, :binary_id, false)
+    use_device_code_flow = Keyword.get(opts, :device_code, false)
+
+    schemas =
+      @required_schemas
+      |> Enum.concat(@optional_schemas)
+      |> Enum.filter(fn schema_def ->
+        Enum.member?(@required_schemas, schema_def) || use_device_code_flow
+      end)
+
+    for {table, schema} <- schemas do
+      table_name = "#{namespace}_#{table}s"
+      context = Macro.camelize(table_name)
+      module = Macro.camelize("#{namespace}_#{table}")
+      file = "#{Macro.underscore(module)}.ex"
+      module = Module.concat([app_base, context, module])
+      macro = schema
       macro_fields = "#{table}_fields"
-      content      = EEx.eval_string(@template, schema: %{module: module, table: table_name, binary_id: binary_id, macro: macro, macro_fields: macro_fields}, otp_app: context_app)
-      dir          = "lib/#{context_app}/#{Macro.underscore(context)}/"
+
+      content =
+        EEx.eval_string(@template,
+          schema: %{
+            module: module,
+            table: table_name,
+            binary_id: binary_id,
+            macro: macro,
+            macro_fields: macro_fields
+          },
+          otp_app: context_app
+        )
+
+      dir = "lib/#{context_app}/#{Macro.underscore(context)}/"
 
       File.mkdir_p!(dir)
 

--- a/lib/mix/tasks/ex_oauth2_provider.gen.migration.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.gen.migration.ex
@@ -22,15 +22,16 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Migration do
 
     * `-r`, `--repo` - the repo module
     * `--binary-id` - use binary id for primary keys
+    * `--device-code - create the tables needed for the device code flow
     * `--namespace` - namespace to prepend table and schema module name
   """
   use Mix.Task
 
   alias Mix.{Ecto, ExOauth2Provider, ExOauth2Provider.Migration}
 
-  @switches     [binary_id: :boolean, namespace: :string]
-  @default_opts [binary_id: false, namespace: "oauth"]
-  @mix_task     "ex_oauth2_provider.gen.migrations"
+  @switches [binary_id: :boolean, device_code: :boolean, namespace: :string]
+  @default_opts [binary_id: false, device_code: false, namespace: "oauth"]
+  @mix_task "ex_oauth2_provider.gen.migrations"
 
   @impl true
   def run(args) do
@@ -53,8 +54,8 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Migration do
   end
 
   defp create_migration_files(%{repo: repo, namespace: namespace} = config) do
-    name         = "Create#{Macro.camelize(namespace)}Tables"
-    content      = Migration.gen(name, namespace, config)
+    name = "Create#{Macro.camelize(namespace)}Tables"
+    content = Migration.gen(name, namespace, config)
 
     Migration.create_migration_file(repo, name, content)
   end

--- a/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
@@ -11,16 +11,22 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Schemas do
   ## Arguments
 
     * `--binary-id` - use binary id for primary keys
-    * `--namespace` - namespace to prepend table and schema module name
     * `--context-app` - context app to use for path and module names
+    * `--device-code` - generate an optional schema for device code grants
+    * `--namespace` - namespace to prepend table and schema module name
   """
   use Mix.Task
 
   alias Mix.{ExOauth2Provider, ExOauth2Provider.Schema}
 
-  @switches     [binary_id: :boolean, context_app: :string, namespace: :string]
-  @default_opts [binary_id: false, namespace: "oauth"]
-  @mix_task     "ex_oauth2_provider.gen.migrations"
+  @switches [
+    binary_id: :boolean,
+    context_app: :string,
+    device_code: :boolean,
+    namespace: :string
+  ]
+  @default_opts [binary_id: false, device_code: false, namespace: "oauth"]
+  @mix_task "ex_oauth2_provider.gen.migrations"
 
   @impl true
   def run(args) do
@@ -34,9 +40,21 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Schemas do
 
   defp parse({config, _parsed, _invalid}), do: config
 
-  defp create_schema_files(%{binary_id: binary_id, namespace: namespace} = config) do
-   context_app = Map.get(config, :context_app) || ExOauth2Provider.otp_app()
+  defp create_schema_files(
+         %{
+           binary_id: binary_id,
+           context_app: context_app,
+           device_code: device_code,
+           namespace: namespace
+         } = config
+       ) do
+    context_app = context_app || ExOauth2Provider.otp_app()
 
-    Schema.create_schema_files(context_app, namespace, binary_id: binary_id)
+    Schema.create_schema_files(
+      context_app,
+      namespace,
+      binary_id: binary_id,
+      device_code: device_code
+    )
   end
 end

--- a/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization_test.exs
@@ -1,0 +1,171 @@
+defmodule ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorizationTest do
+  use ExOauth2Provider.TestCase
+
+  alias Dummy.OauthDeviceGrants.OauthDeviceGrant
+  alias ExOauth2Provider.Config
+  alias ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization
+  alias ExOauth2Provider.Test.{Fixtures, QueryHelpers}
+
+  @config [otp_app: :ex_oauth2_provider]
+
+  setup do
+    application =
+      Fixtures.application(
+        uid: "abc123",
+        scopes: "app:read app:write"
+      )
+
+    {:ok, %{application: application}}
+  end
+
+  describe "#process_request/2" do
+    test "returns :ok tuple when request is valid", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code"
+      }
+
+      {:ok,
+       %{
+         device_code: device_code,
+         expires_in: expires_in,
+         interval: interval,
+         user_code: user_code,
+         verification_uri: verification_uri
+       }} = DeviceAuthorization.process_request(request, @config)
+
+      assert device_code =~ ~r/[a-z0-9=_-]{44}/i
+      assert expires_in == Config.authorization_code_expires_in(@config)
+      assert interval == Config.device_flow_polling_interval(@config)
+      assert user_code =~ ~r/[A-Z0-9]{8}/
+      refute verification_uri === nil
+
+      device_grant = QueryHelpers.get_latest_inserted(OauthDeviceGrant)
+
+      assert device_code == device_grant.device_code
+      assert expires_in == device_grant.expires_in
+      assert user_code == device_grant.user_code
+      assert device_grant.scopes == ""
+      assert device_grant.application_id == application.id
+      assert device_grant.resource_owner_id == nil
+    end
+
+    test "returns :error tuple when client_id is not given" do
+      request = %{"response_type" => "device_code"}
+
+      {
+        :error,
+        %{
+          error: :invalid_request,
+          error_description: message
+        },
+        :bad_request
+      } = DeviceAuthorization.process_request(request, @config)
+
+      assert message =~ ~r/missing required param client_id/i
+    end
+
+    test "returns :error tuple when client_id is not found" do
+      request = %{
+        "client_id" => "this-is-non-existent",
+        "response_type" => "device_code"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_client,
+          error_description: message
+        },
+        :unauthorized
+      } = DeviceAuthorization.process_request(request, @config)
+
+      assert message =~ ~r/unknown client/i
+    end
+
+    test "accepts optional scopes when given", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code",
+        "scope" => "app:read"
+      }
+
+      {:ok, _payload} = DeviceAuthorization.process_request(request, @config)
+      device_grant = QueryHelpers.get_latest_inserted(OauthDeviceGrant)
+
+      assert device_grant.scopes == "app:read"
+    end
+
+    test "returns :error tuple when scope is invalid", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code",
+        "scope" => "app:read app:write BAD:THING"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_scope,
+          error_description: message
+        },
+        :bad_request
+      } = DeviceAuthorization.process_request(request, @config)
+
+      assert message =~ ~r/scope is invalid/i
+    end
+
+    test "deletes expired grants during successful grant creation", %{application: application} do
+      device_grant = Fixtures.device_grant()
+
+      inserted_at =
+        QueryHelpers.timestamp(
+          OauthDeviceGrant,
+          :inserted_at,
+          seconds: -device_grant.expires_in
+        )
+
+      QueryHelpers.change!(device_grant, inserted_at: inserted_at)
+
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code"
+      }
+
+      {:ok, _payload} = DeviceAuthorization.process_request(request, @config)
+      latest_device_grant = QueryHelpers.get_latest_inserted(OauthDeviceGrant)
+
+      assert device_grant.id != latest_device_grant.id
+      assert QueryHelpers.count(OauthDeviceGrant) == 1
+    end
+  end
+
+  describe "#process_request/2 when application has no scopes" do
+    setup %{application: application} do
+      application = QueryHelpers.change!(application, scopes: "")
+
+      %{application: application}
+    end
+
+    test "it allows generic scopes", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code",
+        "scope" => "read"
+      }
+
+      {:ok, _payload} = DeviceAuthorization.process_request(request, @config)
+    end
+
+    test "it denies granular scopes", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code",
+        "scope" => "app:read"
+      }
+
+      {:error, %{error: :invalid_scope}, :bad_request} =
+        DeviceAuthorization.process_request(request, @config)
+    end
+  end
+end

--- a/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction_test.exs
@@ -1,0 +1,139 @@
+defmodule ExOauth2Provider.Authorization.DeviceCode.UserInteractionTest do
+  use ExOauth2Provider.TestCase
+
+  alias Dummy.OauthDeviceGrants.OauthDeviceGrant
+  alias ExOauth2Provider.Authorization.DeviceCode.UserInteraction
+  alias ExOauth2Provider.Test.{Fixtures, QueryHelpers}
+
+  @config [otp_app: :ex_oauth2_provider]
+
+  setup do
+    application =
+      Fixtures.application(
+        uid: "abc123",
+        scopes: "app:read app:write"
+      )
+
+    device_grant = Fixtures.device_grant(application_id: application.id)
+    owner = Fixtures.resource_owner()
+
+    {
+      :ok,
+      %{
+        application: application,
+        device_grant: device_grant,
+        owner: owner
+      }
+    }
+  end
+
+  describe "#authorize/3" do
+    test "updates the grant and responds with :ok tuple with the grant", context do
+      %{device_grant: device_grant, owner: owner} = context
+
+      request = %{
+        "response_type" => "device_code",
+        "user_code" => device_grant.user_code
+      }
+
+      {:ok, updated_grant} = UserInteraction.process_request(owner, request, @config)
+
+      assert updated_grant.id == device_grant.id
+      assert updated_grant.user_code == nil
+      assert updated_grant.resource_owner_id == owner.id
+    end
+
+    test "returns invalid_user_code when user_code is missing", context do
+      %{owner: owner} = context
+
+      request = %{"response_type" => "device_code"}
+
+      {
+        :error,
+        %{
+          error: error_code,
+          error_description: message
+        },
+        status_code
+      } = UserInteraction.process_request(owner, request, @config)
+
+      assert error_code == :user_code_missing
+      assert status_code == :bad_request
+      assert message =~ ~r/missing the required param user_code/i
+    end
+
+    test "returns invalid_user_code when no grant is found", %{owner: owner} do
+      request = %{
+        "response_type" => "device_code",
+        "user_code" => "non-existent-code"
+      }
+
+      {
+        :error,
+        %{
+          error: error_code,
+          error_description: message
+        },
+        status_code
+      } = UserInteraction.process_request(owner, request, @config)
+
+      assert error_code == :invalid_user_code
+      assert status_code == :unprocessable_entity
+      assert message =~ ~r/code is invalid/i
+    end
+
+    test "returns expired_user_code when the grant is expired", context do
+      %{device_grant: device_grant, owner: owner} = context
+
+      inserted_at =
+        QueryHelpers.timestamp(
+          OauthDeviceGrant,
+          :inserted_at,
+          seconds: -device_grant.expires_in
+        )
+
+      QueryHelpers.change!(device_grant, inserted_at: inserted_at)
+
+      request = %{
+        "response_type" => "device_code",
+        "user_code" => device_grant.user_code
+      }
+
+      {
+        :error,
+        %{
+          error: error_code,
+          error_description: message
+        },
+        status_code
+      } = UserInteraction.process_request(owner, request, @config)
+
+      assert error_code == :expired_user_code
+      assert status_code == :unprocessable_entity
+      assert message =~ ~r/user_code has expired/i
+    end
+
+    test "returns invalid_request when the DB update fails unexpectedly", context do
+      %{device_grant: device_grant} = context
+      non_existent_owner = %OauthDeviceGrant{id: "blah"}
+
+      request = %{
+        "response_type" => "device_code",
+        "user_code" => device_grant.user_code
+      }
+
+      {
+        :error,
+        %{
+          error: error_code,
+          error_description: message
+        },
+        status_code
+      } = UserInteraction.process_request(non_existent_owner, request, @config)
+
+      assert error_code == :invalid_owner
+      assert status_code == :unprocessable_entity
+      assert message =~ ~r/owner is invalid/i
+    end
+  end
+end

--- a/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization/strategy/device_code_test.exs
@@ -1,0 +1,54 @@
+defmodule ExOauth2Provider.Authorization.DeviceCodeTest do
+  use ExOauth2Provider.TestCase
+
+  alias Dummy.OauthDeviceGrants.OauthDeviceGrant
+  alias ExOauth2Provider.Authorization
+  alias ExOauth2Provider.Test.Fixtures
+
+  @config [otp_app: :ex_oauth2_provider]
+
+  setup do
+    application =
+      Fixtures.application(
+        uid: "abc123",
+        scopes: "app:read app:write"
+      )
+
+    {:ok, %{application: application}}
+  end
+
+  describe "#authorize/3" do
+    test "invokes the user interaction and approves the device grant", context do
+      %{application: application} = context
+      device_grant = Fixtures.device_grant(application_id: application.id)
+      owner = Fixtures.resource_owner()
+
+      request = %{
+        "response_type" => "device_code",
+        "user_code" => device_grant.user_code
+      }
+
+      {:ok, %OauthDeviceGrant{}} = Authorization.authorize(owner, request, @config)
+    end
+  end
+
+  describe "#preauthorize/3" do
+    test "invokes the device authorization and creats the device grant", context do
+      %{application: application} = context
+
+      request = %{
+        "client_id" => application.uid,
+        "response_type" => "device_code"
+      }
+
+      {:ok,
+       %{
+         device_code: _device_code,
+         expires_in: _expires_in,
+         interval: _interval,
+         user_code: _user_code,
+         verification_uri: _verification_uri
+       }} = Authorization.preauthorize(nil, request, @config)
+    end
+  end
+end

--- a/test/ex_oauth2_provider/oauth2/token/strategy/device_code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/device_code_test.exs
@@ -1,0 +1,501 @@
+defmodule ExOauth2Provider.Token.DeviceCodeTest do
+  use ExOauth2Provider.TestCase
+
+  alias Dummy.OauthDeviceGrants.OauthDeviceGrant
+  alias Dummy.OauthAccessTokens.OauthAccessToken
+  alias ExOauth2Provider.{Config, Token}
+  alias ExOauth2Provider.AccessTokens
+  alias ExOauth2Provider.Test.{Fixtures, QueryHelpers}
+
+  @config [otp_app: :ex_oauth2_provider]
+
+  setup do
+    application =
+      Fixtures.application(
+        uid: "abc123",
+        scopes: "app:read app:write",
+        secret: ""
+      )
+
+    owner = Fixtures.resource_owner()
+
+    grant =
+      Fixtures.device_grant(
+        application_id: application.id,
+        resource_owner_id: owner.id,
+        user_code: nil
+      )
+
+    {
+      :ok,
+      %{
+        application: application,
+        grant: grant,
+        owner: owner,
+        polling_interval: Config.device_flow_polling_interval(@config)
+      }
+    }
+  end
+
+  describe "#grant/2 when request is valid" do
+    test "it returns the access token and deletes the grant", context do
+      %{application: application, grant: grant, owner: owner} = context
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :ok,
+        %{
+          access_token: access_token,
+          expires: expires,
+          refresh_token: refresh_token,
+          scope: scope,
+          token_type: token_type
+        }
+      } = Token.grant(request, @config)
+
+      assert access_token =~ ~r/[a-z0-9]{32,}/i
+      assert expires == Config.access_token_expires_in(@config)
+      assert refresh_token =~ ~r/[a-z0-9]{32,}/i
+      assert scope == ""
+      assert token_type == "bearer"
+      assert QueryHelpers.count(OauthDeviceGrant) == 0
+
+      record = QueryHelpers.get_latest_inserted(OauthAccessToken)
+
+      assert record.application_id == application.id
+      assert record.expires_in == expires
+      assert record.previous_refresh_token == ""
+      assert record.refresh_token == refresh_token
+      assert record.resource_owner_id == owner.id
+      assert record.revoked_at == nil
+      assert record.scopes == scope
+      assert record.token == access_token
+    end
+  end
+
+  describe "#grant/2 when device is polling too frequently" do
+    test "it returns the slow_down error and updates the last polled timestamp", context do
+      %{
+        application: application,
+        grant: grant,
+        polling_interval: polling_interval
+      } = context
+
+      last_polled_at =
+        QueryHelpers.timestamp(
+          OauthDeviceGrant,
+          :last_polled_at,
+          seconds: -polling_interval
+        )
+
+      QueryHelpers.change!(grant, last_polled_at: last_polled_at)
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{error: :slow_down},
+        :bad_request
+      } = Token.grant(request, @config)
+
+      grant = QueryHelpers.get_latest_inserted(OauthDeviceGrant)
+
+      assert grant.last_polled_at > last_polled_at
+    end
+  end
+
+  describe "#grant/2 when previous requests were received and polling rate is OK" do
+    test "it does not block the request and behaves normally", context do
+      %{
+        application: application,
+        grant: grant,
+        polling_interval: polling_interval
+      } = context
+
+      last_polled_at =
+        QueryHelpers.timestamp(
+          OauthDeviceGrant,
+          :last_polled_at,
+          seconds: -(polling_interval + 1)
+        )
+
+      QueryHelpers.change!(grant, last_polled_at: last_polled_at)
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, _payload} = Token.grant(request, @config)
+    end
+  end
+
+  describe "#grant/2 when the grant is not approved yet but still valid" do
+    test "it returns the authorization_pending error and updates the last polled timestamp",
+         context do
+      %{application: application, grant: grant} = context
+      original_last_polled_at = grant.last_polled_at
+
+      QueryHelpers.change!(
+        grant,
+        resource_owner_id: nil,
+        user_code: "still-waiting"
+      )
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{error: :authorization_pending},
+        :bad_request
+      } = Token.grant(request, @config)
+
+      grant = QueryHelpers.get_latest_inserted(OauthDeviceGrant)
+
+      assert grant.last_polled_at > original_last_polled_at
+    end
+  end
+
+  describe "#grant/2 when the device code has expired" do
+    test "it returns the expired_token error and destroys the grant", context do
+      %{application: application, grant: grant} = context
+
+      inserted_at =
+        QueryHelpers.timestamp(
+          OauthDeviceGrant,
+          :inserted_at,
+          seconds: -Config.access_token_expires_in(@config)
+        )
+
+      QueryHelpers.change!(grant, inserted_at: inserted_at)
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{error: :expired_token},
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert QueryHelpers.count(OauthDeviceGrant) == 0
+    end
+  end
+
+  describe "#grant/2 when device code is invalid" do
+    test "it returns the invalid_grant error", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => "this-wont-match",
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_grant,
+          error_description: message
+        },
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/grant is invalid/i
+    end
+  end
+
+  describe "#grant/2 when device code is missing" do
+    test "it returns the invalid_request error", %{application: application} do
+      request = %{
+        "client_id" => application.uid,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_request,
+          error_description: message
+        },
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/missing required param device_code/i
+    end
+  end
+
+  describe "#grant/2 when client_id is invalid" do
+    test "it returns the invalid_client error", %{grant: grant} do
+      request = %{
+        "client_id" => "this-is-not-matching",
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_client,
+          error_description: message
+        },
+        :unauthorized
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/unknown client/i
+    end
+  end
+
+  describe "#grant/2 when client_id is missing" do
+    test "it returns the invalid_request error" do
+      request = %{
+        "device_code" => "abc123",
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_request,
+          error_description: message
+        },
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/missing required param client_id/i
+    end
+  end
+
+  describe "#grant/2 when client_id and device_code is missing" do
+    test "it returns the invalid_request error" do
+      request = %{"grant_type" => "urn:ietf:params:oauth:grant-type:device_code"}
+
+      {
+        :error,
+        %{
+          error: :invalid_request,
+          error_description: message
+        },
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/missing required param client_id, device_code/i
+    end
+  end
+
+  describe "#grant/2 when application has no scopes" do
+    test "it creates the token with the configured default scope", context do
+      %{application: application, grant: grant} = context
+
+      QueryHelpers.change!(application, scopes: "")
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, _payload} = Token.grant(request, @config)
+
+      default_scopes =
+        @config
+        |> Config.default_scopes()
+        |> Enum.join(",")
+
+      access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
+
+      assert access_token.scopes == default_scopes
+    end
+  end
+
+  describe "#grant/2 when client_secret is given and valid" do
+    test "it behaves like normal", %{application: application, grant: grant} do
+      application = QueryHelpers.change!(application, secret: "secret")
+
+      request = %{
+        "client_id" => application.uid,
+        "client_secret" => application.secret,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, _payload} = Token.grant(request, @config)
+    end
+  end
+
+  describe "#grant/2 when client_secret is given and invalid" do
+    test "it returns invalid_client error", context do
+      %{application: application, grant: grant} = context
+
+      request = %{
+        "client_id" => application.uid,
+        "client_secret" => "invalid-secret",
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {
+        :error,
+        %{error: :invalid_client},
+        :unauthorized
+      } = Token.grant(request, @config)
+    end
+  end
+
+  describe "#grant/2 when valid scopes are given" do
+    test "it adds them to the token", %{application: application, grant: grant} do
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code",
+        "scope" => "app:read"
+      }
+
+      {:ok, _payload} = Token.grant(request, @config)
+      access_token = QueryHelpers.get_latest_inserted(OauthAccessToken)
+
+      assert access_token.scopes == "app:read"
+    end
+  end
+
+  describe "#grant/2 when invalid scopes are given" do
+    test "it returns invalid_scope error", context do
+      %{application: application, grant: grant} = context
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code",
+        "scope" => "ability_to_delete_all_the_things!"
+      }
+
+      {
+        :error,
+        %{
+          error: :invalid_scope,
+          error_description: message
+        },
+        :bad_request
+      } = Token.grant(request, @config)
+
+      assert message =~ ~r/scope is invalid/i
+    end
+  end
+
+  describe "#grant/2 when configured to not use refresh token" do
+    test "it does not set the refresh token", context do
+      %{application: application, grant: grant} = context
+      modified_config = Keyword.put(@config, :use_refresh_token, false)
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, payload} = Token.grant(request, modified_config)
+
+      record = QueryHelpers.get_latest_inserted(OauthAccessToken)
+
+      assert record.refresh_token == nil
+      refute record.token == nil
+      assert record.refresh_token == payload.refresh_token
+      assert record.token == payload.access_token
+    end
+  end
+
+  describe "#grant/2 when a valid access token already exists" do
+    test "it returns the existing token and deletes the grant", context do
+      %{application: application, grant: grant, owner: owner} = context
+
+      existing_token =
+        Fixtures.access_token(
+          application: application,
+          resource_owner: owner,
+          scopes: ""
+        )
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, payload} = Token.grant(request, @config)
+
+      assert existing_token.token == payload.access_token
+      assert QueryHelpers.count(OauthAccessToken) == 1
+      assert QueryHelpers.count(OauthDeviceGrant) == 0
+    end
+  end
+
+  describe "#grant/2 when a revoked access token already exists" do
+    test "it creates a new one", context do
+      %{application: application, grant: grant, owner: owner} = context
+
+      revoked_token =
+        [application: application, resource_owner: owner, scopes: ""]
+        |> Fixtures.access_token()
+        |> AccessTokens.revoke!()
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, payload} = Token.grant(request, @config)
+
+      refute revoked_token.token == payload.access_token
+      assert QueryHelpers.count(OauthAccessToken) == 2
+    end
+  end
+
+  describe "#grant/2 when an expired access token already exists" do
+    test "it creates a new one", context do
+      %{application: application, grant: grant, owner: owner} = context
+
+      expired_token =
+        Fixtures.access_token(
+          application: application,
+          resource_owner: owner,
+          scopes: ""
+        )
+
+      inserted_at =
+        QueryHelpers.timestamp(
+          OauthAccessToken,
+          :inserted_at,
+          seconds: -Config.access_token_expires_in(@config)
+        )
+
+      QueryHelpers.change!(expired_token, inserted_at: inserted_at)
+
+      request = %{
+        "client_id" => application.uid,
+        "device_code" => grant.device_code,
+        "grant_type" => "urn:ietf:params:oauth:grant-type:device_code"
+      }
+
+      {:ok, payload} = Token.grant(request, @config)
+
+      refute expired_token.token == payload.access_token
+      assert QueryHelpers.count(OauthAccessToken) == 2
+    end
+  end
+end

--- a/test/ex_oauth2_provider/oauth2/utils/device_flow_test.exs
+++ b/test/ex_oauth2_provider/oauth2/utils/device_flow_test.exs
@@ -1,0 +1,85 @@
+defmodule ExOauth2Provider.Utils.DeviceFlowTest do
+  use ExOauth2Provider.TestCase
+
+  alias ExOauth2Provider.Utils.DeviceFlow
+
+  describe "#generate_device_code/1" do
+    test "returns a unique 32 char string that's base64 encoded and url safe" do
+      expected_length =
+        "01234567890123456789012345678912"
+        |> Base.url_encode64()
+        |> String.length()
+
+      codes = Enum.map(1..10, fn _n -> DeviceFlow.generate_device_code() end)
+
+      num_uniq_codes =
+        codes
+        |> Enum.uniq()
+        |> Enum.count()
+
+      assert num_uniq_codes == 10
+
+      assert Enum.all?(
+               codes,
+               fn code ->
+                 assert code =~ ~r/[a-z0-9=_-]{#{expected_length}}/i
+               end
+             )
+    end
+
+    test "uses the length in the config when defined" do
+      code =
+        DeviceFlow.generate_device_code(
+          otp_app: :ex_oauth2_provider,
+          device_flow_device_code_length: 10
+        )
+
+      expected_length =
+        "0123456789"
+        |> Base.url_encode64()
+        |> String.length()
+
+      assert String.length(code) == expected_length
+    end
+  end
+
+  describe "#generate_user_code/1" do
+    test "returns a unique 8 char alpha-numeric string" do
+      codes = Enum.map(1..10, fn _n -> DeviceFlow.generate_user_code() end)
+
+      num_uniq_codes =
+        codes
+        |> Enum.uniq()
+        |> Enum.count()
+
+      assert num_uniq_codes == 10
+
+      assert Enum.all?(
+               codes,
+               fn code ->
+                 assert code =~ ~r/[a-z0-9]{8}/i
+               end
+             )
+    end
+
+    test "returns a code the same length as device_flow_device_code_length when given" do
+      code =
+        DeviceFlow.generate_user_code(
+          otp_app: :ex_oauth2_provider,
+          device_flow_user_code_length: 4
+        )
+
+      assert String.length(code) == 4
+    end
+
+    test "returns a code using the value of device_flow_user_code_base when given" do
+      code =
+        DeviceFlow.generate_user_code(
+          otp_app: :ex_oauth2_provider,
+          device_flow_user_code_base: 2
+        )
+
+      assert code =~ ~r/[01]{8}/
+    end
+  end
+end

--- a/test/mix/tasks/ex_oauth2_provider.gen.migration_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.gen.migration_test.exs
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.MigrationTest do
 
   @tmp_path Path.join(["tmp", inspect(Migration)])
   @migrations_path Path.join(@tmp_path, "migrations")
-  @options ~w(-r #{inspect Repo})
+  @options ~w(-r #{inspect(Repo)})
 
   setup do
     File.rm_rf!(@tmp_path)
@@ -27,18 +27,25 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.MigrationTest do
 
       file = @migrations_path |> Path.join(migration_file) |> File.read!()
 
-      assert file =~ "defmodule #{inspect Repo}.Migrations.CreateOauthTables do"
+      assert file =~ "defmodule #{inspect(Repo)}.Migrations.CreateOauthTables do"
       assert file =~ "use Ecto.Migration"
       assert file =~ "def change do"
       assert file =~ "add :owner_id, references(:users, on_delete: :nothing)"
       assert file =~ "add :resource_owner_id, references(:users, on_delete: :nothing)"
       refute file =~ "add :owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
-      refute file =~ "add :resource_owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
+
+      refute file =~
+               "add :resource_owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
+
       refute file =~ ":oauth_applications, primary_key: false"
       refute file =~ ":oauth_access_grants, primary_key: false"
       refute file =~ ":oauth_access_tokens, primary_key: false"
       refute file =~ "add :id, :binary_id, primary_key: true"
-      refute file =~ "add :application_id, references(:oauth_applications, on_delete: :nothing, type: binary_id)"
+
+      refute file =~
+               "add :application_id, references(:oauth_applications, on_delete: :nothing, type: binary_id)"
+
+      refute file =~ ":oauth_device_grants"
     end)
   end
 
@@ -53,12 +60,52 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.MigrationTest do
       refute file =~ "add :owner_id, :integer, null: false"
       refute file =~ "add :resource_owner_id, :integer"
       assert file =~ "add :owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
-      assert file =~ "add :resource_owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
+
+      assert file =~
+               "add :resource_owner_id, references(:users, on_delete: :nothing, type: :binary_id)"
+
       assert file =~ ":oauth_applications, primary_key: false"
       assert file =~ ":oauth_access_grants, primary_key: false"
       assert file =~ ":oauth_access_tokens, primary_key: false"
       assert file =~ "add :id, :binary_id, primary_key: true"
-      assert file =~ "add :application_id, references(:oauth_applications, on_delete: :nothing, type: :binary_id)"
+
+      assert file =~
+               "add :application_id, references(:oauth_applications, on_delete: :nothing, type: :binary_id)"
+    end)
+  end
+
+  test "it creates device_grants table when --device-code option is given" do
+    File.cd!(@tmp_path, fn ->
+      Migration.run(@options ++ ~w(--device-code))
+
+      assert [migration_file] = File.ls!(@migrations_path)
+
+      file = @migrations_path |> Path.join(migration_file) |> File.read!()
+
+      assert file =~ ":oauth_applications"
+      assert file =~ ":oauth_access_grants"
+      assert file =~ ":oauth_access_tokens"
+
+      create_table_content =
+        [
+          "    create table(:oauth_device_grants) do",
+          "      add :device_code, :string, null: false",
+          "      add :expires_in, :integer, null: false",
+          "      add :last_polled_at, :utc_datetime",
+          "      add :scopes, :string",
+          "      add :user_code, :string",
+          "      add :application_id, references(:oauth_applications, on_delete: :nothing)",
+          "      add :resource_owner_id, references(:users, on_delete: :nothing)",
+          "",
+          "      timestamps()",
+          "    end",
+          "",
+          "    create unique_index(:oauth_device_grants, [:device_code])",
+          "    create unique_index(:oauth_device_grants, [:user_code])"
+        ]
+        |> Enum.join("\n")
+
+      assert file =~ create_table_content
     end)
   end
 
@@ -66,9 +113,11 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.MigrationTest do
     File.cd!(@tmp_path, fn ->
       Migration.run(@options)
 
-      assert_raise Mix.Error, "migration can't be created, there is already a migration file with name CreateOauthTables.", fn ->
-        Migration.run(@options)
-      end
+      assert_raise Mix.Error,
+                   "migration can't be created, there is already a migration file with name CreateOauthTables.",
+                   fn ->
+                     Migration.run(@options)
+                   end
     end)
   end
 end

--- a/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
@@ -5,7 +5,8 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
 
   @tmp_path Path.join(["tmp", inspect(Schemas)])
   @options ~w(--context-app test)
-  @files ["access_grant", "access_token", "application"]
+  @required_files ~w(access_grant access_token application)
+  @optional_files ~w(device_grant)
 
   setup do
     File.rm_rf!(@tmp_path)
@@ -20,17 +21,78 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
 
       Schemas.run(@options)
 
-      for file <- @files do
+      for file <- @required_files do
         path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
 
         assert File.exists?(path)
 
-        module  = Module.concat(["Test", Macro.camelize("oauth_#{file}s"), Macro.camelize("oauth_#{file}")])
-        macro   = Module.concat(["ExOauth2Provider", Macro.camelize("#{file}s"), Macro.camelize("#{file}")])
+        module =
+          Module.concat([
+            "Test",
+            Macro.camelize("oauth_#{file}s"),
+            Macro.camelize("oauth_#{file}")
+          ])
+
+        macro =
+          Module.concat([
+            "ExOauth2Provider",
+            Macro.camelize("#{file}s"),
+            Macro.camelize("#{file}")
+          ])
+
         content = File.read!(path)
 
-        assert content =~ "defmodule #{inspect module} do"
-        assert content =~ "use #{inspect macro}, otp_app: :test"
+        assert content =~ "defmodule #{inspect(module)} do"
+        assert content =~ "use #{inspect(macro)}, otp_app: :test"
+        assert content =~ "schema \"oauth_#{file}s\" do"
+        assert content =~ "#{file}_fields()"
+      end
+
+      for file <- @optional_files do
+        path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
+
+        refute File.exists?(path)
+      end
+    end)
+  end
+
+  test "it creates the device_grant schema when config has device_code grant flow" do
+    File.cd!(@tmp_path, fn ->
+      root_path = Path.join(["lib", "test"])
+
+      @options
+      |> Enum.concat(~w(--device-code))
+      |> Schemas.run()
+
+      for file <- @required_files do
+        path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
+
+        assert File.exists?(path)
+      end
+
+      for file <- @optional_files do
+        path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
+
+        assert File.exists?(path)
+
+        module =
+          Module.concat([
+            "Test",
+            Macro.camelize("oauth_#{file}s"),
+            Macro.camelize("oauth_#{file}")
+          ])
+
+        macro =
+          Module.concat([
+            "ExOauth2Provider",
+            Macro.camelize("#{file}s"),
+            Macro.camelize("#{file}")
+          ])
+
+        content = File.read!(path)
+
+        assert content =~ "defmodule #{inspect(module)} do"
+        assert content =~ "use #{inspect(macro)}, otp_app: :test"
         assert content =~ "schema \"oauth_#{file}s\" do"
         assert content =~ "#{file}_fields()"
       end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -2,7 +2,15 @@ defmodule ExOauth2Provider.Test.Fixtures do
   @moduledoc false
 
   alias ExOauth2Provider.AccessTokens
-  alias Dummy.{OauthApplications.OauthApplication, OauthAccessGrants.OauthAccessGrant, Repo, Users.User}
+
+  alias Dummy.{
+    OauthApplications.OauthApplication,
+    OauthAccessGrants.OauthAccessGrant,
+    OauthDeviceGrants.OauthDeviceGrant,
+    Repo,
+    Users.User
+  }
+
   alias Ecto.Changeset
 
   def resource_owner(attrs \\ []) do
@@ -16,13 +24,16 @@ defmodule ExOauth2Provider.Test.Fixtures do
 
   def application(attrs \\ []) do
     resource_owner = Keyword.get(attrs, :resource_owner) || resource_owner()
-    attrs          = [
-      owner_id: resource_owner.id,
-      uid: "test",
-      secret: "secret",
-      name: "OAuth Application",
-      redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
-      scopes: "public read write"]
+
+    attrs =
+      [
+        owner_id: resource_owner.id,
+        uid: "test",
+        secret: "secret",
+        name: "OAuth Application",
+        redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+        scopes: "public read write"
+      ]
       |> Keyword.merge(attrs)
       |> Keyword.drop([:resource_owner])
 
@@ -51,7 +62,6 @@ defmodule ExOauth2Provider.Test.Fixtures do
     access_token
   end
 
-
   def access_grant(application, user, code, redirect_uri) do
     attrs = [
       expires_in: 900,
@@ -64,6 +74,20 @@ defmodule ExOauth2Provider.Test.Fixtures do
     ]
 
     %OauthAccessGrant{}
+    |> Changeset.change(attrs)
+    |> Repo.insert!()
+  end
+
+  def device_grant(attrs \\ []) do
+    attrs =
+      [
+        device_code: "device-code",
+        expires_in: 900,
+        user_code: "user-code"
+      ]
+      |> Keyword.merge(attrs)
+
+    %OauthDeviceGrant{}
     |> Changeset.change(attrs)
     |> Repo.insert!()
   end

--- a/test/support/lib/dummy/oauth_device_grants/oauth_device_grant.ex
+++ b/test/support/lib/dummy/oauth_device_grants/oauth_device_grant.ex
@@ -1,0 +1,16 @@
+defmodule Dummy.OauthDeviceGrants.OauthDeviceGrant do
+  @moduledoc false
+
+  use Ecto.Schema
+  use ExOauth2Provider.DeviceGrants.DeviceGrant, otp_app: :ex_oauth2_provider
+
+  if System.get_env("UUID") do
+    @primary_key {:id, :binary_id, autogenerate: true}
+    @foreign_key_type :binary_id
+  end
+
+  schema "oauth_device_grants" do
+    device_grant_fields()
+    timestamps()
+  end
+end

--- a/test/support/priv/migrations/2_create_oauth_tables.exs
+++ b/test/support/priv/migrations/2_create_oauth_tables.exs
@@ -1,6 +1,11 @@
 require Mix.ExOauth2Provider.Migration
 
 binary_id = if System.get_env("UUID"), do: true, else: false
+
 "CreateOauthTables"
-|> Mix.ExOauth2Provider.Migration.gen("oauth", %{repo: ExOauth2Provider.Test.Repo, binary_id: binary_id})
+|> Mix.ExOauth2Provider.Migration.gen("oauth", %{
+  repo: ExOauth2Provider.Test.Repo,
+  binary_id: binary_id,
+  device_code: true
+})
 |> Code.eval_string()

--- a/test/support/query_helpers.ex
+++ b/test/support/query_helpers.ex
@@ -21,6 +21,10 @@ defmodule ExOauth2Provider.Test.QueryHelpers do
   defp convert_timestamp({key, %DateTime{} = value}), do: {key, %{value | microsecond: {0, 0}}}
   defp convert_timestamp(any), do: any
 
+  def count(schema) do
+    Repo.one(from(r in schema, select: count(r.id)))
+  end
+
   def get_latest_inserted(module) do
     module
     |> order_by([x], desc: x.id)


### PR DESCRIPTION
This adds optional support for the OAuth2 Device Flow. https://www.oauth.com/oauth2-servers/device-flow/

## Specs
- Device code is generated as a url safe base64 string, 32 chars long per https://datatracker.ietf.org/doc/html/rfc6750#section-2.1 (configurable length)
- User code is an 8 character string with A-Z and 0-9 (configurable length)
- Migration and schemas are generated by passing the `--device-code` flag to the mix task.
- The grant flow can be enabled by adding `device_code` to the `grant_flows` option in the config.

## Highlights
### Arch
- device_grant schema generation [DONE]
- device_grants table migration [DONE]
- device_code to the supported grant flows [DONE]

### Access Requests
- device_code preauthorization strategy [DONE]
- device_code preauthorization success response [DONE]
- device_code preauthorization error responses [DONE]

### Authorization Requests
- device_code authorization strategy [DONE]
- device_code authorization success response DONE]
- device_code authorization error responses [DONE]

### Token Requests
- device_code token grant strategy [DONE]
- device_code token polling responses [DONE]
- device_code token grant response [DONE]
- device_code token grant error responses [DONE]

### Configuration
- user code length configurable [DONE]
- device code length configurable [DONE]
- device code base configurable [DONE]
- verification_uri configurable [DONE]

## Other Changes
- Added `.tool-versions` for asdf tooling. I used the elixir and erlang versions from the last successful travis ci build.
- Updated `.gitignore` to ignore `.tool-versions` (not sure if that was a desired change so disincluded it)
- Updated `.gitignore` to exclude vim swap files
- Some formatting changes per `mix format` integration with vim
- made a few error functions take optional http status since oauth2 error responses are intended to be `400` and invalid client response is `401` per https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
- Added `Validation` module for dealing with common validations like required params and scope
- Added `DeviceFlow` module for generating various kinds of codes.