### PR TITLE
[PATCH] Fix schema generation when --context-app is not given and migration gen documentation

### DIFF
--- a/lib/ex_oauth2_provider/device_grants/device_grant.ex
+++ b/lib/ex_oauth2_provider/device_grants/device_grant.ex
@@ -62,7 +62,7 @@ defmodule ExOauth2Provider.DeviceGrants.DeviceGrant do
   end
 
   alias Ecto.Changeset
-  alias ExOauth2Provider.{Mixin.Scopes, Utils}
+  alias ExOauth2Provider.Mixin.Scopes
 
   @spec changeset(Ecto.Schema.t(), map(), keyword()) :: Changeset.t()
   def changeset(grant, params, config) do

--- a/lib/ex_oauth2_provider/device_grants/device_grants.ex
+++ b/lib/ex_oauth2_provider/device_grants/device_grants.ex
@@ -94,8 +94,6 @@ defmodule ExOauth2Provider.DeviceGrants do
     |> get_repo(config).update!()
   end
 
-  defp device_grant_schema(config), do: Config.device_grant(config)
-
   defp fetch_grant_with_user_code({schema, repo}, user_code) do
     # from(d in schema, preload: [:application], where: d.user_code == ^user_code)
     schema

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
@@ -3,7 +3,6 @@ defmodule ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization do
     Config,
     DeviceGrants,
     Authorization.Utils,
-    Scopes,
     Utils.DeviceFlow,
     Utils.Error,
     Utils.Validation

--- a/lib/ex_oauth2_provider/oauth2/token/utils.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/utils.ex
@@ -5,10 +5,12 @@ defmodule ExOauth2Provider.Token.Utils do
 
   @doc false
   @spec load_client({:ok, map()}, keyword()) :: {:ok, map()} | {:error, map()}
+  def load_client(context, config, opts \\ [])
+
   def load_client(
         {:ok, %{request: request = %{"client_id" => client_id}} = params},
         config,
-        opts \\ []
+        opts
       ) do
     client_secret = Map.get(request, "client_secret", "")
 

--- a/lib/mix/tasks/ex_oauth2_provider.gen.migration.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.gen.migration.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Migration do
 
     * `-r`, `--repo` - the repo module
     * `--binary-id` - use binary id for primary keys
-    * `--device-code - create the tables needed for the device code flow
+    * `--device-code` - create the tables needed for the device code flow
     * `--namespace` - namespace to prepend table and schema module name
   """
   use Mix.Task

--- a/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
+++ b/lib/mix/tasks/ex_oauth2_provider.gen.schemas.ex
@@ -43,12 +43,16 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.Schemas do
   defp create_schema_files(
          %{
            binary_id: binary_id,
-           context_app: context_app,
            device_code: device_code,
            namespace: namespace
          } = config
        ) do
-    context_app = context_app || ExOauth2Provider.otp_app()
+    context_app =
+      Map.get(
+        config,
+        :context_app,
+        ExOauth2Provider.otp_app()
+      )
 
     Schema.create_schema_files(
       context_app,

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule ExOauth2Provider.Mixfile do
       app: :ex_oauth2_provider,
       version: @version,
       elixir: "~> 1.8",
-      elixirc_paths: elixirc_paths(Mix.env),
-      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
 
       # Hex
@@ -23,7 +23,7 @@ defmodule ExOauth2Provider.Mixfile do
   end
 
   def application do
-    [extra_applications: extra_applications(Mix.env)]
+    [extra_applications: extra_applications(Mix.env())]
   end
 
   defp extra_applications(:test), do: [:ecto, :logger]
@@ -39,12 +39,11 @@ defmodule ExOauth2Provider.Mixfile do
 
       # Dev and test dependencies
       {:credo, "~> 1.1.0", only: [:dev, :test]},
-
       {:ex_doc, ">= 0.0.0", only: :dev},
-
-      {:ecto_sql, "~> 3.0.0", only: :test},
+      {:ecto_sql, "~> 3.0.0", only: [:dev, :test]},
       {:plug_cowboy, "~> 2.0", only: :test},
-      {:postgrex, "~> 0.14", only: :test}]
+      {:postgrex, "~> 0.14", only: :test}
+    ]
   end
 
   defp package do

--- a/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.gen.schemas_test.exs
@@ -26,20 +26,8 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
 
         assert File.exists?(path)
 
-        module =
-          Module.concat([
-            "Test",
-            Macro.camelize("oauth_#{file}s"),
-            Macro.camelize("oauth_#{file}")
-          ])
-
-        macro =
-          Module.concat([
-            "ExOauth2Provider",
-            Macro.camelize("#{file}s"),
-            Macro.camelize("#{file}")
-          ])
-
+        module = modulize(file)
+        macro = macroize(file)
         content = File.read!(path)
 
         assert content =~ "defmodule #{inspect(module)} do"
@@ -52,6 +40,25 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
         path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
 
         refute File.exists?(path)
+      end
+    end)
+  end
+
+  test "it uses the configured otp_app when --context-app is not given" do
+    File.cd!(@tmp_path, fn ->
+      # Test config defines :ex_oauth2_provider as the otp_app
+      root_path = Path.join(["lib", "ex_oauth2_provider"])
+
+      Schemas.run([])
+
+      for file <- @required_files do
+        path = Path.join([root_path, "oauth_#{file}s", "oauth_#{file}.ex"])
+
+        assert File.exists?(path)
+
+        macro = macroize(file)
+
+        assert File.read!(path) =~ "use #{inspect(macro)}, otp_app: :ex_oauth2_provider"
       end
     end)
   end
@@ -75,20 +82,8 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
 
         assert File.exists?(path)
 
-        module =
-          Module.concat([
-            "Test",
-            Macro.camelize("oauth_#{file}s"),
-            Macro.camelize("oauth_#{file}")
-          ])
-
-        macro =
-          Module.concat([
-            "ExOauth2Provider",
-            Macro.camelize("#{file}s"),
-            Macro.camelize("#{file}")
-          ])
-
+        module = modulize(file)
+        macro = macroize(file)
         content = File.read!(path)
 
         assert content =~ "defmodule #{inspect(module)} do"
@@ -97,5 +92,21 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.SchemasTest do
         assert content =~ "#{file}_fields()"
       end
     end)
+  end
+
+  defp modulize(file) do
+    Module.concat([
+      "Test",
+      Macro.camelize("oauth_#{file}s"),
+      Macro.camelize("oauth_#{file}")
+    ])
+  end
+
+  defp macroize(file) do
+    Module.concat([
+      "ExOauth2Provider",
+      Macro.camelize("#{file}s"),
+      Macro.camelize("#{file}")
+    ])
   end
 end


### PR DESCRIPTION
The --context-app was accidentally made a requirement by adding it to the function pattern match. So now it's not required and uses the configured otp_app as I wanted in the first place... covered by a test.

## Extra fixes
- fixed a typo in the documentation so it works now.
- removed compiler warnings for unused alias' and unused functions
- updated ecto_sql to be a dev dependency and test dependency so it doesn't cause compiler warnings in dev environments.