### PR TITLE
[PATCH] Fix typespecs for responses

### DIFF
--- a/lib/ex_oauth2_provider/oauth2/authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization.ex
@@ -18,7 +18,11 @@ defmodule ExOauth2Provider.Authorization do
   does not have a user, there is no session.
   """
   @spec preauthorize(Schema.t() | nil, map(), keyword()) ::
-          Response.success() | Response.error() | Response.redirect() | Response.native_redirect()
+          Response.preauthorization_success()
+          | Response.device_preauthorization_success()
+          | Response.error()
+          | Response.redirect()
+          | Response.native_redirect()
   def preauthorize(resource_owner, request, config \\ []) do
     case validate_response_type(request, config) do
       {:error, :invalid_response_type} ->
@@ -36,7 +40,10 @@ defmodule ExOauth2Provider.Authorization do
   Authorize access for a device. See #preauthorize/3 for more details.
   """
   @spec preauthorize_device(map(), keyword()) ::
-          Response.success() | Response.error() | Response.redirect() | Response.native_redirect()
+          Response.device_preauthorization_success()
+          | Response.error()
+          | Response.redirect()
+          | Response.native_redirect()
   def preauthorize_device(request, config \\ []) do
     # This wraps preauthorize but since there's no user or response type
     # in these requests we can pass what's needed.

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code.ex
@@ -1,19 +1,26 @@
 defmodule ExOauth2Provider.Authorization.DeviceCode do
+  @moduledoc """
+  This module is the glue for the various steps and integrates it into
+  the authorization architecture that this package provides. It separates
+  the concerns to simplify things.
+  """
+  alias Ecto.Schema
   alias ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization
   alias ExOauth2Provider.Authorization.DeviceCode.UserInteraction
-
-  # NOTE: This module is the glue for the various steps and integrates it into
-  # the authorization architecture that this package provides. It separates
-  # the concerns to simplify things.
+  alias ExOauth2Provider.Authorization.Utils.Response
 
   # User Interaction Request - approve the grant with user code
   # https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+  @spec authorize(Schema.t(), map(), keyword()) ::
+          Response.authorization_success() | Response.error()
   def authorize(resource_owner, request, config \\ []) do
     UserInteraction.process_request(resource_owner, request, config)
   end
 
   # Device Authorization Request
   # https://tools.ietf.org/html/rfc8628#section-3.1
+  @spec preauthorize(Schema.t(), map(), keyword()) ::
+          Response.device_preauthorization_success() | Response.error()
   def preauthorize(_resource_owner, request, config \\ []) do
     DeviceAuthorization.process_request(request, config)
   end

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/device_authorization.ex
@@ -1,8 +1,13 @@
 defmodule ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization do
+  @moduledoc """
+  Device authorization request handler
+  https://tools.ietf.org/html/rfc8628#section-3.1
+  """
   alias ExOauth2Provider.{
     Config,
     DeviceGrants,
     Authorization.Utils,
+    Authorization.Utils.Response,
     Utils.DeviceFlow,
     Utils.Error,
     Utils.Validation
@@ -10,8 +15,8 @@ defmodule ExOauth2Provider.Authorization.DeviceCode.DeviceAuthorization do
 
   @required_params ~w(client_id)
 
-  # Device Authorization Request
-  # https://tools.ietf.org/html/rfc8628#section-3.1
+  @spec process_request(map(), keyword()) ::
+          Response.device_preauthorization_success() | Response.error()
   def process_request(request, config \\ []) do
     %{config: config, request: request}
     |> Validation.validate_required_query_params(@required_params)

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/device_code/user_interaction.ex
@@ -1,6 +1,10 @@
 defmodule ExOauth2Provider.Authorization.DeviceCode.UserInteraction do
-  alias Ecto.Changeset
-  alias ExOauth2Provider.DeviceGrants
+  @moduledoc """
+  User Interaction Request - approve the grant with user code
+  https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+  """
+  alias Ecto.{Changeset, Schema}
+  alias ExOauth2Provider.{Authorization.Utils.Response, DeviceGrants}
 
   @message_lookup [
     expired_user_code: "The user_code has expired.",
@@ -15,8 +19,8 @@ defmodule ExOauth2Provider.Authorization.DeviceCode.UserInteraction do
     user_code_missing: :bad_request
   ]
 
-  # User Interaction Request - approve the grant with user code
-  # https://datatracker.ietf.org/doc/html/rfc8628#section-3.3
+  @spec process_request(Schema.t(), map(), keyword()) ::
+          Response.device_authorization_success() | Response.error()
   def process_request(owner, request, config \\ []) do
     %{config: config, owner: owner, user_code: Map.get(request, "user_code")}
     |> find_device_grant()

--- a/lib/ex_oauth2_provider/oauth2/authorization/utils/response.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/utils/response.ex
@@ -1,12 +1,16 @@
 defmodule ExOauth2Provider.Authorization.Utils.Response do
   @moduledoc false
 
+  alias Ecto.Schema
   alias ExOauth2Provider.{RedirectURI, Scopes, Utils}
 
-  @type native_redirect :: {:native_redirect, %{code: binary()}}
-  @type redirect :: {:redirect, binary()}
+  @type authorization_success :: {:ok, map()}
+  @type device_authorization_success :: {:ok, Schema.t()}
+  @type device_preauthorization_success :: {:ok, map()}
   @type error :: {:error, map(), integer()}
-  @type success :: {:ok, map()}
+  @type native_redirect :: {:native_redirect, %{code: binary()}}
+  @type preauthorization_success :: {:ok, Schema.t(), list()}
+  @type redirect :: {:redirect, binary()}
 
   @doc false
   @spec error_response({:error, map()}, keyword()) :: error() | redirect() | native_redirect()
@@ -15,7 +19,7 @@ defmodule ExOauth2Provider.Authorization.Utils.Response do
 
   @doc false
   @spec preauthorize_response({:ok, map()} | {:error, map()}, keyword()) ::
-          success() | error() | redirect() | native_redirect()
+          preauthorization_success() | error() | redirect() | native_redirect()
   def preauthorize_response({:ok, %{grant: grant} = params}, config),
     do: build_response(params, %{code: grant.token}, config)
 
@@ -27,7 +31,7 @@ defmodule ExOauth2Provider.Authorization.Utils.Response do
 
   @doc false
   @spec authorize_response({:ok, map()} | {:error, map()}, keyword()) ::
-          success() | error() | redirect() | native_redirect()
+          authorization_success() | error() | redirect() | native_redirect()
   def authorize_response({:ok, %{grant: grant} = params}, config),
     do: build_response(params, %{code: grant.token}, config)
 

--- a/test/ex_oauth2_provider/device_grants/device_grants_test.exs
+++ b/test/ex_oauth2_provider/device_grants/device_grants_test.exs
@@ -4,7 +4,7 @@ defmodule ExOauth2Provider.DeviceGrantsTest do
   alias ExOauth2Provider.DeviceGrants
   alias ExOauth2Provider.Test.Fixtures
   alias ExOauth2Provider.Test.QueryHelpers
-  alias Dummy.{OauthDeviceGrants.OauthDeviceGrant, Repo, Users.User}
+  alias Dummy.{OauthDeviceGrants.OauthDeviceGrant, Users.User}
 
   @config [otp_app: :ex_oauth2_provider]
 


### PR DESCRIPTION
While implementing the authorization code flow I discovered a bug in the response typespecs. The `preauthorize` response is actually a tuple of `{:ok, app, scopes}` which is not defined in the response typespec - so it mismatches. This blocks a project form using it because the pattern won't match the defined succes response of `{:ok, map()}`.

After fixing that I went ahead and added specs to the device flow code and realized they too have different respones types than the codebase supports so I added specific types for them to separate the concerns and ensure things line up.