### PR TITLE
[MINOR] Add skip authorization feature

### DIFF
--- a/lib/ex_oauth2_provider/applications/application.ex
+++ b/lib/ex_oauth2_provider/applications/application.ex
@@ -42,11 +42,12 @@ defmodule ExOauth2Provider.Applications.Application do
   @doc false
   def attrs() do
     [
-    {:name, :string, null: false},
-    {:uid, :string, null: false},
-    {:secret, :string, null: false, default: ""},
-    {:redirect_uri, :string, null: false},
-    {:scopes, :string, null: false, default: ""},
+      {:is_trusted, :boolean, null: false, default: false},
+      {:name, :string, null: false},
+      {:redirect_uri, :string, null: false},
+      {:scopes, :string, null: false, default: ""},
+      {:secret, :string, null: false, default: ""},
+      {:uid, :string, null: false}
     ]
   end
 
@@ -67,7 +68,7 @@ defmodule ExOauth2Provider.Applications.Application do
       use ExOauth2Provider.Schema, unquote(config)
 
       # For Phoenix integrations
-      if Code.ensure_loaded?(Phoenix.Param), do: @derive {Phoenix.Param, key: :uid}
+      if Code.ensure_loaded?(Phoenix.Param), do: @derive({Phoenix.Param, key: :uid})
 
       import unquote(__MODULE__), only: [application_fields: 0]
     end
@@ -87,7 +88,7 @@ defmodule ExOauth2Provider.Applications.Application do
   def changeset(application, params, config \\ []) do
     application
     |> maybe_new_application_changeset(params, config)
-    |> Changeset.cast(params, [:name, :secret, :redirect_uri, :scopes])
+    |> Changeset.cast(params, [:is_trusted, :name, :secret, :redirect_uri, :scopes])
     |> Changeset.validate_required([:name, :uid, :redirect_uri])
     |> validate_secret_not_nil()
     |> Scopes.validate_scopes(nil, config)
@@ -98,13 +99,13 @@ defmodule ExOauth2Provider.Applications.Application do
   defp validate_secret_not_nil(changeset) do
     case Changeset.get_field(changeset, :secret) do
       nil -> Changeset.add_error(changeset, :secret, "can't be blank")
-      _   -> changeset
+      _ -> changeset
     end
   end
 
   defp maybe_new_application_changeset(application, params, config) do
     case Ecto.get_meta(application, :state) do
-      :built  -> new_application_changeset(application, params, config)
+      :built -> new_application_changeset(application, params, config)
       :loaded -> application
     end
   end
@@ -127,18 +128,20 @@ defmodule ExOauth2Provider.Applications.Application do
       url
       |> RedirectURI.validate(config)
       |> case do
-         {:error, error} -> Changeset.add_error(changeset, :redirect_uri, error)
-         {:ok, _}        -> changeset
-       end
+        {:error, error} -> Changeset.add_error(changeset, :redirect_uri, error)
+        {:ok, _} -> changeset
+      end
     end)
   end
 
   defp put_uid(%{changes: %{uid: _}} = changeset), do: changeset
+
   defp put_uid(%{} = changeset) do
     Changeset.change(changeset, %{uid: Utils.generate_token()})
   end
 
   defp put_secret(%{changes: %{secret: _}} = changeset), do: changeset
+
   defp put_secret(%{} = changeset) do
     Changeset.change(changeset, %{secret: Utils.generate_token()})
   end

--- a/lib/ex_oauth2_provider/behaviors/skip_authorization.ex
+++ b/lib/ex_oauth2_provider/behaviors/skip_authorization.ex
@@ -1,0 +1,23 @@
+defmodule ExOauth2Provider.Behaviors.SkipAuthorization do
+  @moduledoc """
+  Define the rules used to determine if authorization can be skipped. If your
+  app has unique criteria then implement it.
+
+  For example:
+
+  defmodule MyModule do
+    @behaviour ExOauth2Provider.Behaviors.SkipAuthorization
+
+    def skip_authorization(user, application) do
+      user.super_cool? || application.trusted?
+    end
+  end
+  """
+  alias ExOauth2Provider.Applications.Application
+  alias ExOauth2Provider.Schema
+
+  @callback skip_authorization?(
+              user :: Schema.t(),
+              application :: Application.t()
+            ) :: boolean()
+end

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -178,6 +178,41 @@ defmodule ExOauth2Provider.Config do
           device_flow_verification_uri: "https://really.cool.site/device"
         """)
 
+  @doc """
+  This returns the function to use to determine if we should skip authorization
+  and automatically grant an authorization token. This is disabled by default.
+
+  To implement it you can set :skip_authorization in the config to any function
+  you wish to use to determine if it applies to the given user and/or application.
+
+  The behavior ExOauth2Provider.Behaviors.SkipAuthorization is provided to help
+  facilitate proper implementation.
+
+  For example:
+
+    config :my_app, ExOauth2Provider,
+      skip_authorization_with: &MyModule.my_function/2
+
+
+  Then you can do whatever you want with your implementation!
+
+    defmodule MyModule do
+      @behaviour ExOauth2Provider.Behaviors.SkipAuthorization
+
+      def skip_authorization(user, application) do
+        user.super_cool? || application.trusted?
+      end
+    end
+  """
+  @spec skip_authorization(keyword()) :: function()
+  def skip_authorization(config) do
+    get(
+      config,
+      :skip_authorization_with,
+      &ExOauth2Provider.Features.skip_authorization?/2
+    )
+  end
+
   defp get(config, key, value \\ nil) do
     otp_app = Keyword.get(config, :otp_app)
 

--- a/lib/ex_oauth2_provider/features.ex
+++ b/lib/ex_oauth2_provider/features.ex
@@ -1,0 +1,8 @@
+defmodule ExOauth2Provider.Features do
+  @moduledoc """
+  Determine the status of configurable features.
+  """
+  @behaviour ExOauth2Provider.Behaviors.SkipAuthorization
+
+  def skip_authorization?(_user, _application), do: false
+end

--- a/test/ex_oauth2_provider/applications/application_test.exs
+++ b/test/ex_oauth2_provider/applications/application_test.exs
@@ -2,7 +2,9 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
   use ExOauth2Provider.TestCase
 
   alias ExOauth2Provider.Applications.Application
+  alias ExOauth2Provider.Test.Fixtures
   alias Dummy.OauthApplications.OauthApplication
+  alias Dummy.Repo
 
   describe "changeset/2 with existing application" do
     setup do
@@ -35,11 +37,8 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
     end
 
     test "require valid redirect uri", %{application: application} do
-      ["",
-      "invalid",
-      "https://example.com invalid",
-      "https://example.com http://example.com"]
-      |> Enum.each(fn(redirect_uri) ->
+      ["", "invalid", "https://example.com invalid", "https://example.com http://example.com"]
+      |> Enum.each(fn redirect_uri ->
         changeset = Application.changeset(application, %{redirect_uri: redirect_uri})
         assert changeset.errors[:redirect_uri]
       end)
@@ -48,6 +47,15 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
     test "doesn't require scopes", %{application: application} do
       changeset = Application.changeset(application, %{scopes: ""})
       refute changeset.errors[:scopes]
+    end
+
+    test "allows is_trusted to be changed" do
+      app =
+        Fixtures.application()
+        |> Application.changeset(%{is_trusted: true})
+        |> Repo.update!()
+
+      assert app.is_trusted == true
     end
   end
 
@@ -63,7 +71,7 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
     end
 
     schema "oauth_applications" do
-      belongs_to :owner, __MODULE__
+      belongs_to(:owner, __MODULE__)
 
       application_fields()
       timestamps()
@@ -71,6 +79,7 @@ defmodule ExOauth2Provider.Applications.ApplicationTest do
   end
 
   test "with overridden `:owner`" do
-    assert %Ecto.Association.BelongsTo{owner: OverrideOwner} = OverrideOwner.__schema__(:association, :owner)
+    assert %Ecto.Association.BelongsTo{owner: OverrideOwner} =
+             OverrideOwner.__schema__(:association, :owner)
   end
 end

--- a/test/ex_oauth2_provider/oauth2/authorization/strategy/code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization/strategy/code_test.exs
@@ -1,27 +1,40 @@
 defmodule ExOauth2Provider.Authorization.CodeTest do
   use ExOauth2Provider.TestCase
 
+  alias Ecto.Changeset
   alias ExOauth2Provider.{Authorization, Config, Scopes}
   alias ExOauth2Provider.Test.{Fixtures, QueryHelpers}
   alias Dummy.{OauthAccessGrants.OauthAccessGrant, Repo}
 
-  @client_id                "Jf5rM8hQBc"
-  @valid_request            %{"client_id" => @client_id, "response_type" => "code", "scope" => "app:read app:write"}
-  @invalid_request          %{error: :invalid_request,
-                              error_description: "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
-                            }
-  @invalid_client           %{error: :invalid_client,
-                              error_description: "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
-                            }
-  @invalid_scope            %{error: :invalid_scope,
-                              error_description: "The requested scope is invalid, unknown, or malformed."
-                            }
-  @invalid_redirect_uri     %{error: :invalid_redirect_uri,
-                              error_description: "The redirect uri included is not valid."
-                            }
-  @access_denied            %{error: :access_denied,
-                              error_description: "The resource owner or authorization server denied the request."
-                            }
+  @config [otp_app: :ex_oauth2_provider]
+  @client_id "Jf5rM8hQBc"
+  @valid_request %{
+    "client_id" => @client_id,
+    "response_type" => "code",
+    "scope" => "app:read app:write"
+  }
+  @invalid_request %{
+    error: :invalid_request,
+    error_description:
+      "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
+  }
+  @invalid_client %{
+    error: :invalid_client,
+    error_description:
+      "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
+  }
+  @invalid_scope %{
+    error: :invalid_scope,
+    error_description: "The requested scope is invalid, unknown, or malformed."
+  }
+  @invalid_redirect_uri %{
+    error: :invalid_redirect_uri,
+    error_description: "The redirect uri included is not valid."
+  }
+  @access_denied %{
+    error: :access_denied,
+    error_description: "The resource owner or authorization server denied the request."
+  }
 
   setup do
     resource_owner = Fixtures.resource_owner()
@@ -30,50 +43,70 @@ defmodule ExOauth2Provider.Authorization.CodeTest do
   end
 
   test "#preauthorize/3 error when no resource owner" do
-    assert Authorization.preauthorize(nil, @valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.preauthorize(nil, @valid_request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#preauthorize/3 error when no client_id", %{resource_owner: resource_owner} do
     request = Map.delete(@valid_request, "client_id")
 
-    assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.preauthorize(resource_owner, request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#preauthorize/3 error when invalid client", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"client_id" => "invalid"})
 
-    assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_client, :unprocessable_entity}
+    assert Authorization.preauthorize(resource_owner, request, @config) ==
+             {:error, @invalid_client, :unprocessable_entity}
   end
 
   test "#preauthorize/3", %{resource_owner: resource_owner, application: application} do
     expected_scopes = Scopes.to_list(@valid_request["scope"])
 
-    assert Authorization.preauthorize(resource_owner, @valid_request, otp_app: :ex_oauth2_provider) == {:ok, application, expected_scopes}
+    assert Authorization.preauthorize(resource_owner, @valid_request, @config) ==
+             {:ok, application, expected_scopes}
   end
 
-  test "#preauthorize/3 when previous access token with different application scopes", %{resource_owner: resource_owner, application: application} do
-    access_token = Fixtures.access_token(resource_owner: resource_owner, application: application, scopes: "app:read")
+  test "#preauthorize/3 when previous access token with different application scopes", %{
+    resource_owner: resource_owner,
+    application: application
+  } do
+    access_token =
+      Fixtures.access_token(
+        resource_owner: resource_owner,
+        application: application,
+        scopes: "app:read"
+      )
+
     expected_scopes = Scopes.to_list(@valid_request["scope"])
 
-    assert Authorization.preauthorize(resource_owner, @valid_request, otp_app: :ex_oauth2_provider) == {:ok, application, expected_scopes}
+    assert Authorization.preauthorize(resource_owner, @valid_request, @config) ==
+             {:ok, application, expected_scopes}
 
     QueryHelpers.change!(access_token, scopes: "app:read app:write")
     request = Map.merge(@valid_request, %{"scope" => "app:read"})
     expected_scopes = Scopes.to_list(request["scope"])
 
-    assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:ok, application, expected_scopes}
+    assert Authorization.preauthorize(resource_owner, request, @config) ==
+             {:ok, application, expected_scopes}
   end
 
-  test "#preauthorize/3 with limited scope", %{resource_owner: resource_owner, application: application} do
+  test "#preauthorize/3 with limited scope", %{
+    resource_owner: resource_owner,
+    application: application
+  } do
     request = Map.merge(@valid_request, %{"scope" => "app:read"})
 
-    assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:ok, application, ["app:read"]}
+    assert Authorization.preauthorize(resource_owner, request, @config) ==
+             {:ok, application, ["app:read"]}
   end
 
   test "#preauthorize/3 error when invalid scope", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"scope" => "app:invalid"})
 
-    assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_scope, :unprocessable_entity}
+    assert Authorization.preauthorize(resource_owner, request, @config) ==
+             {:error, @invalid_scope, :unprocessable_entity}
   end
 
   describe "#preauthorize/3 when application has no scope" do
@@ -86,45 +119,157 @@ defmodule ExOauth2Provider.Authorization.CodeTest do
     test "with limited server scope", %{resource_owner: resource_owner, application: application} do
       request = Map.merge(@valid_request, %{"scope" => "read"})
 
-      assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:ok, application, ["read"]}
+      assert Authorization.preauthorize(resource_owner, request, @config) ==
+               {:ok, application, ["read"]}
     end
 
     test "error when invalid server scope", %{resource_owner: resource_owner} do
       request = Map.merge(@valid_request, %{"scope" => "invalid"})
 
-      assert Authorization.preauthorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_scope, :unprocessable_entity}
+      assert Authorization.preauthorize(resource_owner, request, @config) ==
+               {:error, @invalid_scope, :unprocessable_entity}
     end
   end
 
-  test "#preauthorize/3 when previous access token with same scopes", %{resource_owner: resource_owner, application: application} do
-    Fixtures.access_token(resource_owner: resource_owner, application: application, scopes: @valid_request["scope"])
+  test "#preauthorize/3 when previous access token with same scopes", %{
+    resource_owner: resource_owner,
+    application: application
+  } do
+    Fixtures.access_token(
+      resource_owner: resource_owner,
+      application: application,
+      scopes: @valid_request["scope"]
+    )
 
-    assert {:native_redirect, %{code: code}} = Authorization.preauthorize(resource_owner, @valid_request, otp_app: :ex_oauth2_provider)
+    assert {:native_redirect, %{code: code}} =
+             Authorization.preauthorize(resource_owner, @valid_request,
+               otp_app: :ex_oauth2_provider
+             )
+
     access_grant = QueryHelpers.get_latest_inserted(OauthAccessGrant)
 
     assert code == access_grant.token
   end
 
+  describe "#preauthorize/3 when :skip_authorization_with is configured to be true" do
+    setup %{application: application, resource_owner: resource_owner} do
+      {
+        :ok,
+        %{
+          application: application,
+          config:
+            Keyword.put(
+              @config,
+              :skip_authorization_with,
+              fn _user, _application ->
+                true
+              end
+            ),
+          resource_owner: resource_owner
+        }
+      }
+    end
+
+    test "creates the grant and responds with native_redirect when url is native", context do
+      %{
+        application: application,
+        config: config,
+        resource_owner: resource_owner
+      } = context
+
+      assert {:native_redirect, %{code: code}} =
+               Authorization.preauthorize(
+                 resource_owner,
+                 @valid_request,
+                 config
+               )
+
+      access_grant =
+        Repo.get_by(
+          OauthAccessGrant,
+          application_id: application.id,
+          resource_owner_id: resource_owner.id,
+          token: code
+        )
+
+      refute access_grant == nil
+    end
+
+    test "creates the grant andresponds with redirect when url is not native", context do
+      %{
+        application: application,
+        config: config,
+        resource_owner: resource_owner
+      } = context
+
+      application
+      |> Changeset.change(redirect_uri: "https://foo.test/callback")
+      |> Repo.update!()
+
+      assert {:redirect, url} =
+               Authorization.preauthorize(
+                 resource_owner,
+                 @valid_request,
+                 config
+               )
+
+      access_grant =
+        Repo.get_by(
+          OauthAccessGrant,
+          application_id: application.id,
+          resource_owner_id: resource_owner.id
+        )
+
+      assert url =~ access_grant.token
+    end
+
+    test "pre-validation errors are passed through", context do
+      %{config: config, resource_owner: resource_owner} = context
+
+      assert {:error, @invalid_client, _status} =
+               Authorization.preauthorize(
+                 resource_owner,
+                 Map.put(@valid_request, "client_id", "foo"),
+                 config
+               )
+    end
+
+    test "request validation errors are passed through", context do
+      %{config: config, resource_owner: resource_owner} = context
+
+      assert {:error, @invalid_redirect_uri, _status} =
+               Authorization.preauthorize(
+                 resource_owner,
+                 Map.put(@valid_request, "redirect_uri", "foo"),
+                 config
+               )
+    end
+  end
+
   test "#authorize/3 rejects when no resource owner" do
-    assert Authorization.authorize(nil, @valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.authorize(nil, @valid_request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#authorize/3 error when invalid client", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"client_id" => "invalid"})
 
-    assert Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_client, :unprocessable_entity}
+    assert Authorization.authorize(resource_owner, request, @config) ==
+             {:error, @invalid_client, :unprocessable_entity}
   end
 
   test "#authorize/3 error when no client_id", %{resource_owner: resource_owner} do
     request = Map.delete(@valid_request, "client_id")
 
-    assert Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.authorize(resource_owner, request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#authorize/3 error when invalid scope", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"scope" => "app:read app:profile"})
 
-    assert Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_scope, :unprocessable_entity}
+    assert Authorization.authorize(resource_owner, request, @config) ==
+             {:error, @invalid_scope, :unprocessable_entity}
   end
 
   describe "#authorize/3 when application has no scope" do
@@ -136,12 +281,16 @@ defmodule ExOauth2Provider.Authorization.CodeTest do
 
     test "error when invalid server scope", %{resource_owner: resource_owner} do
       request = Map.merge(@valid_request, %{"scope" => "public profile"})
-      assert Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_scope, :unprocessable_entity}
+
+      assert Authorization.authorize(resource_owner, request, @config) ==
+               {:error, @invalid_scope, :unprocessable_entity}
     end
 
     test "generates grant", %{resource_owner: resource_owner} do
       request = Map.merge(@valid_request, %{"scope" => "public"})
-      assert {:native_redirect, %{code: code}} = Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider)
+
+      assert {:native_redirect, %{code: code}} =
+               Authorization.authorize(resource_owner, request, @config)
 
       access_grant = Repo.get_by(OauthAccessGrant, token: code)
       assert access_grant.resource_owner_id == resource_owner.id
@@ -151,53 +300,83 @@ defmodule ExOauth2Provider.Authorization.CodeTest do
   test "#authorize/3 error when invalid redirect uri", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"redirect_uri" => "/invalid/path"})
 
-    assert Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_redirect_uri, :unprocessable_entity}
+    assert Authorization.authorize(resource_owner, request, @config) ==
+             {:error, @invalid_redirect_uri, :unprocessable_entity}
   end
 
   test "#authorize/3 generates grant", %{resource_owner: resource_owner} do
-    assert {:native_redirect, %{code: code}} = Authorization.authorize(resource_owner, @valid_request, otp_app: :ex_oauth2_provider)
+    assert {:native_redirect, %{code: code}} =
+             Authorization.authorize(resource_owner, @valid_request, @config)
+
     access_grant = Repo.get_by(OauthAccessGrant, token: code)
 
     assert access_grant.resource_owner_id == resource_owner.id
-    assert access_grant.expires_in == Config.authorization_code_expires_in(otp_app: :ex_oauth2_provider)
+
+    assert access_grant.expires_in ==
+             Config.authorization_code_expires_in(otp_app: :ex_oauth2_provider)
+
     assert access_grant.scopes == @valid_request["scope"]
   end
 
-  test "#authorize/3 generates grant with redirect uri", %{resource_owner: resource_owner, application: application} do
-    QueryHelpers.change!(application, redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path")
+  test "#authorize/3 generates grant with redirect uri", %{
+    resource_owner: resource_owner,
+    application: application
+  } do
+    QueryHelpers.change!(application,
+      redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path"
+    )
 
-    request = Map.merge(@valid_request, %{"redirect_uri" => "https://example.com/path?param=1", "state" => 40_612})
+    request =
+      Map.merge(@valid_request, %{
+        "redirect_uri" => "https://example.com/path?param=1",
+        "state" => 40_612
+      })
 
-    assert {:redirect, redirect_uri} = Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider)
+    assert {:redirect, redirect_uri} = Authorization.authorize(resource_owner, request, @config)
+
     access_grant = QueryHelpers.get_latest_inserted(OauthAccessGrant)
 
-    assert redirect_uri == "https://example.com/path?code=#{access_grant.token}&param=1&state=40612"
+    assert redirect_uri ==
+             "https://example.com/path?code=#{access_grant.token}&param=1&state=40612"
   end
 
   test "#deny/3 error when no resource owner" do
-    assert Authorization.deny(nil, @valid_request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.deny(nil, @valid_request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#deny/3 error when invalid client", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"client_id" => "invalid"})
 
-    assert Authorization.deny(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_client, :unprocessable_entity}
+    assert Authorization.deny(resource_owner, request, @config) ==
+             {:error, @invalid_client, :unprocessable_entity}
   end
 
   test "#deny/3 error when no client_id", %{resource_owner: resource_owner} do
     request = Map.delete(@valid_request, "client_id")
 
-    assert Authorization.deny(resource_owner, request, otp_app: :ex_oauth2_provider) == {:error, @invalid_request, :bad_request}
+    assert Authorization.deny(resource_owner, request, @config) ==
+             {:error, @invalid_request, :bad_request}
   end
 
   test "#deny/3", %{resource_owner: resource_owner} do
-    assert Authorization.deny(resource_owner, @valid_request, otp_app: :ex_oauth2_provider) == {:error, @access_denied, :unauthorized}
+    assert Authorization.deny(resource_owner, @valid_request, @config) ==
+             {:error, @access_denied, :unauthorized}
   end
 
   test "#deny/3 with redirection uri", %{application: application, resource_owner: resource_owner} do
-    QueryHelpers.change!(application, redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path")
-    request = Map.merge(@valid_request, %{"redirect_uri" => "https://example.com/path?param=1", "state" => 40_612})
+    QueryHelpers.change!(application,
+      redirect_uri: "#{application.redirect_uri}\nhttps://example.com/path"
+    )
 
-    assert Authorization.deny(resource_owner, request, otp_app: :ex_oauth2_provider) == {:redirect, "https://example.com/path?error=access_denied&error_description=The+resource+owner+or+authorization+server+denied+the+request.&param=1&state=40612"}
+    request =
+      Map.merge(@valid_request, %{
+        "redirect_uri" => "https://example.com/path?param=1",
+        "state" => 40_612
+      })
+
+    assert Authorization.deny(resource_owner, request, @config) ==
+             {:redirect,
+              "https://example.com/path?error=access_denied&error_description=The+resource+owner+or+authorization+server+denied+the+request.&param=1&state=40612"}
   end
 end

--- a/test/mix/tasks/ex_oauth2_provider.gen.migration_test.exs
+++ b/test/mix/tasks/ex_oauth2_provider.gen.migration_test.exs
@@ -46,6 +46,10 @@ defmodule Mix.Tasks.ExOauth2Provider.Gen.MigrationTest do
                "add :application_id, references(:oauth_applications, on_delete: :nothing, type: binary_id)"
 
       refute file =~ ":oauth_device_grants"
+
+      # TODO: this could be improved by testing each table indpendently and
+      # completely.
+      assert file =~ "add :is_trusted, :boolean, null: false, default: false"
     end)
   end
 


### PR DESCRIPTION
- Added `AccessGrants.get_active_grant_for_owner_by_token` for safe queries of user tokens for native redirect endpoints that render the token
- Added `Applications.is_trusted` to the schema and db migration
- Added SkipAuthorization behavior to facilitate proper usage in apps
- Added `skip_authorization_with` config key that accepts a function that matches the SkipAuthorization behavior
- Added skip authorization implementation in the Authorization.preauthorize function