### PR TITLE
[MINOR] Make the token authentication function configurable

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -20,4 +20,6 @@ config :ex_oauth2_provider, ExOauth2Provider,
 config :ex_oauth2_provider, Dummy.Repo,
   database: "ex_oauth2_provider_test",
   pool: Ecto.Adapters.SQL.Sandbox,
-  priv: "test/support/priv"
+  priv: "test/support/priv",
+  username: "postgres",
+  password: "postgres"

--- a/lib/ex_oauth2_provider.ex
+++ b/lib/ex_oauth2_provider.ex
@@ -34,6 +34,8 @@ defmodule ExOauth2Provider do
   expire.
   """
 
+  @behaviour ExOauth2Provider.Behaviors.TokenAuthentication
+
   alias ExOauth2Provider.{Config, AccessTokens}
 
   @doc """
@@ -48,9 +50,10 @@ defmodule ExOauth2Provider do
       {:ok, access_token}
       {:error, reason}
   """
-  @spec authenticate_token(binary(), keyword()) :: {:ok, map()} | {:error, any()}
+  @impl ExOauth2Provider.Behaviors.TokenAuthentication
   def authenticate_token(token, config \\ [])
   def authenticate_token(nil, _config), do: {:error, :token_inaccessible}
+
   def authenticate_token(token, config) do
     token
     |> load_access_token(config)
@@ -61,37 +64,40 @@ defmodule ExOauth2Provider do
 
   defp load_access_token(token, config) do
     case AccessTokens.get_by_token(token, config) do
-      nil          -> {:error, :token_not_found}
+      nil -> {:error, :token_not_found}
       access_token -> {:ok, access_token}
     end
   end
 
   defp maybe_revoke_previous_refresh_token({:error, error}, _config), do: {:error, error}
+
   defp maybe_revoke_previous_refresh_token({:ok, access_token}, config) do
     case Config.refresh_token_revoked_on_use?(config) do
-      true  -> revoke_previous_refresh_token(access_token, config)
+      true -> revoke_previous_refresh_token(access_token, config)
       false -> {:ok, access_token}
     end
   end
 
   defp revoke_previous_refresh_token(access_token, config) do
     case AccessTokens.revoke_previous_refresh_token(access_token, config) do
-      {:error, _any}       -> {:error, :no_association_found}
+      {:error, _any} -> {:error, :no_association_found}
       {:ok, _access_token} -> {:ok, access_token}
     end
   end
 
   defp validate_access_token({:error, error}), do: {:error, error}
+
   defp validate_access_token({:ok, access_token}) do
     case AccessTokens.is_accessible?(access_token) do
-      true  -> {:ok, access_token}
+      true -> {:ok, access_token}
       false -> {:error, :token_inaccessible}
     end
   end
 
   defp load_resource_owner({:error, error}, _config), do: {:error, error}
+
   defp load_resource_owner({:ok, access_token}, config) do
-    repo         = Config.repo(config)
+    repo = Config.repo(config)
     access_token = repo.preload(access_token, :resource_owner)
 
     {:ok, access_token}

--- a/lib/ex_oauth2_provider/behaviors/token_authentication.ex
+++ b/lib/ex_oauth2_provider/behaviors/token_authentication.ex
@@ -1,0 +1,8 @@
+defmodule ExOauth2Provider.Behaviors.TokenAuthentication do
+  @moduledoc """
+  Simple behavior for defining a custom token authentication strategy.
+  """
+
+  @callback authenticate_token(token :: binary(), config :: keyword()) ::
+              {:ok, map()} | {:error, any()}
+end

--- a/lib/ex_oauth2_provider/config.ex
+++ b/lib/ex_oauth2_provider/config.ex
@@ -213,6 +213,19 @@ defmodule ExOauth2Provider.Config do
     )
   end
 
+  @doc """
+  Returns a function that is used to verify that a token string is valid.
+  This allows you to add in additional functionality like a caching layer or
+  side effects.
+  """
+  def token_authenticator(config) do
+    get(
+      config,
+      :authenticate_token_with,
+      &ExOauth2Provider.authenticate_token/2
+    )
+  end
+
   defp get(config, key, value \\ nil) do
     otp_app = Keyword.get(config, :otp_app)
 


### PR DESCRIPTION
I had a need to introduce caching to reduce DB access under heavy load. Since the VerifyHeader plug does this authentication and modifies the conn struct I introduced the ability to configure a custom authentify function to use instead of `ExOauth2Provider.authenticate_token/2`. This way one can introduce caching, side-effects or whatever else they need, or customize how the token is authenticated.