### PR TITLE
[MINOR] Implement PKCE setting for each oauth app

### DIFF
--- a/lib/ex_oauth2_provider/access_grants/access_grant.ex
+++ b/lib/ex_oauth2_provider/access_grants/access_grant.ex
@@ -76,10 +76,18 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrant do
   alias Ecto.Changeset
   alias ExOauth2Provider.{Mixin.Scopes, Utils}
 
-  @spec changeset(Ecto.Schema.t(), map(), keyword()) :: Changeset.t()
-  def changeset(grant, params, config) do
-    castable = castable_attrs(config)
-    required = required_attrs(config)
+  @doc """
+  Generate a validated changeset.
+  """
+  @spec changeset(
+          grant :: Ecto.Schema.t(),
+          params :: map(),
+          application :: Ecto.Schema.t(),
+          config :: keyword()
+        ) :: Changeset.t()
+  def changeset(grant, params, application, config) do
+    castable = castable_attrs(application, config)
+    required = required_attrs(application, config)
     params = coerce_params(params)
 
     grant
@@ -104,21 +112,21 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrant do
 
   defp coerce_params(params), do: params
 
-  defp castable_attrs(config) do
+  defp castable_attrs(application, config) do
     castable = [
       :expires_in,
       :redirect_uri,
       :scopes
     ]
 
-    if PKCE.required?(config) do
+    if PKCE.required?(application, config) do
       [:code_challenge, :code_challenge_method] ++ castable
     else
       castable
     end
   end
 
-  defp required_attrs(config) do
+  defp required_attrs(application, config) do
     castable = [
       :application,
       :expires_in,
@@ -127,7 +135,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrant do
       :token
     ]
 
-    if PKCE.required?(config) do
+    if PKCE.required?(application, config) do
       [:code_challenge, :code_challenge_method] ++ castable
     else
       castable

--- a/lib/ex_oauth2_provider/access_grants/access_grants.ex
+++ b/lib/ex_oauth2_provider/access_grants/access_grants.ex
@@ -47,7 +47,7 @@ defmodule ExOauth2Provider.AccessGrants do
     config
     |> Config.access_grant()
     |> struct(resource_owner: resource_owner, application: application)
-    |> AccessGrant.changeset(attrs, config)
+    |> AccessGrant.changeset(attrs, application, config)
     |> Config.repo(config).insert()
   end
 

--- a/lib/ex_oauth2_provider/applications/application.ex
+++ b/lib/ex_oauth2_provider/applications/application.ex
@@ -42,7 +42,6 @@ defmodule ExOauth2Provider.Applications.Application do
   @type t :: Ecto.Schema.t()
   @type pkce_setting :: PKCE.setting()
 
-  @default_pkce_setting :disabled
   @supported_pkce_settings PKCE.settings()
 
   @doc """

--- a/lib/ex_oauth2_provider/applications/application.ex
+++ b/lib/ex_oauth2_provider/applications/application.ex
@@ -37,13 +37,34 @@ defmodule ExOauth2Provider.Applications.Application do
       end
   """
 
+  alias ExOauth2Provider.PKCE
+
   @type t :: Ecto.Schema.t()
+  @type pkce_setting :: PKCE.setting()
+
+  @default_pkce_setting :disabled
+  @supported_pkce_settings PKCE.settings()
+
+  @doc """
+  Returns a list of the supported PKCE settings for an app.
+  """
+  @spec pkce_settings() :: pkce_setting()
+  def pkce_settings, do: @supported_pkce_settings
 
   @doc false
   def attrs() do
     [
       {:is_trusted, :boolean, default: false, null: false},
       {:name, :string},
+      {
+        :pkce,
+        Ecto.Enum,
+        [
+          default: :disabled,
+          null: false,
+          values: @supported_pkce_settings
+        ]
+      },
       {:redirect_uri, :string},
       {:scopes, :string, default: ""},
       {:secret, :string, default: ""},
@@ -88,8 +109,8 @@ defmodule ExOauth2Provider.Applications.Application do
   def changeset(application, params, config \\ []) do
     application
     |> maybe_new_application_changeset(params, config)
-    |> Changeset.cast(params, [:is_trusted, :name, :secret, :redirect_uri, :scopes])
-    |> Changeset.validate_required([:name, :uid, :redirect_uri])
+    |> Changeset.cast(params, [:is_trusted, :name, :pkce, :secret, :redirect_uri, :scopes])
+    |> Changeset.validate_required([:name, :pkce, :uid, :redirect_uri])
     |> validate_secret_not_nil()
     |> Scopes.validate_scopes(nil, config)
     |> validate_redirect_uri(config)

--- a/lib/ex_oauth2_provider/oauth2/authorization.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization.ex
@@ -33,10 +33,10 @@ defmodule ExOauth2Provider.Authorization do
 
   The config is a list of various additional parameters.
 
-  - `:otp_app` - Required. The name of the app to pull config data for.
-  - `:with`    - Optional. This can be a single value or a list of things that
-                 should be included. The only supported value today is `:pkce`
-                 to require PKCE be used.
+  - `:otp_app` - Optional. The name of the app to pull config data for.
+  - `:pkce`    - Optional. Specify whether PKCE is supported and if so what
+                 kinds of challenge is accepted. This is the same as the
+                 app config option but you can manually specify an override.
   """
   @spec preauthorize(Schema.t() | nil, map(), keyword()) ::
           Response.preauthorization_success()
@@ -76,6 +76,15 @@ defmodule ExOauth2Provider.Authorization do
 
   @doc """
   Check ExOauth2Provider.Authorization.Code for usage.
+
+  ## Config
+
+  You can pass in optional fields if desired.
+
+  - `:otp_app` - Optional. The name of the app to pull config data for.
+  - `:pkce`    - Optional. Specify whether PKCE is supported and if so what
+                 kinds of challenge is accepted. This is the same as the
+                 app config option but you can manually specify an override.
   """
   @spec authorize(Schema.t(), map(), keyword()) ::
           {:ok, binary()} | Response.error() | Response.redirect() | Response.native_redirect()
@@ -107,6 +116,15 @@ defmodule ExOauth2Provider.Authorization do
 
   @doc """
   Check ExOauth2Provider.Authorization.Code for usage.
+
+  ## Config
+
+  You can pass in optional fields if desired.
+
+  - `:otp_app` - Optional. The name of the app to pull config data for.
+  - `:pkce`    - Optional. Specify whether PKCE is supported and if so what
+                 kinds of challenge is accepted. This is the same as the
+                 app config option but you can manually specify an override.
   """
   @spec deny(Schema.t(), map(), keyword()) :: Response.error() | Response.redirect()
   def deny(resource_owner, request, config \\ []) do

--- a/lib/ex_oauth2_provider/oauth2/token/request_params.ex
+++ b/lib/ex_oauth2_provider/oauth2/token/request_params.ex
@@ -10,13 +10,13 @@ defmodule ExOauth2Provider.Token.AuthorizationCode.RequestParams do
   """
   @spec valid?(context :: AuthorizationCode.context(), config :: list()) :: boolean()
   def valid?(context, config) when is_map(context) and is_list(config) do
-    with true <- valid_pkce?(context, config) do
-      valid_redirect_uri?(context)
+    with true <- valid_redirect_uri?(context) do
+      valid_pkce?(context, config)
     end
   end
 
   defp valid_pkce?(context, config) do
-    is_required = PKCE.required?(config)
+    is_required = PKCE.required?(context, config)
     (is_required and PKCE.valid?(context, config)) or not is_required
   end
 

--- a/lib/mix/tasks/add_pkce_to_applications.ex
+++ b/lib/mix/tasks/add_pkce_to_applications.ex
@@ -1,0 +1,88 @@
+defmodule Mix.Tasks.ExOauth2Provider.AddPkceToApplications do
+  @shortdoc "Generates migration for adding PKCE field to Applications"
+
+  @moduledoc """
+  Generates a migration file that adds the PKCE field to Applications.
+
+      # Update the default table which is `oauth_applications`
+      mix ex_oauth2_provider.add_pkce_to_applications -r MyApp.Repo
+
+      # Update your custom table name if you used another one
+      mix ex_oauth2_provider.add_pkce_to_applications -r MyApp.Repo --table some_other_name
+
+  This generator will add the oauth2 migration file in `priv/repo/migrations`.
+
+  The repository must be set under `:ecto_repos` in the current app
+  configuration or given via the `-r` option.
+
+  By default, the migration will be generated to the
+  "priv/YOUR_REPO/migrations" directory of the current application but it
+  can be configured to be any subdirectory of `priv` by specifying the
+  `:priv` key under the repository configuration.
+
+  If you have an umbrella application then you must execute this within
+  the target app directory. You can't execute this within an umbrella at
+  the root.
+
+  ## Arguments
+
+    * `-r`, `--repo` - the repo module
+    * `--table` - The name of the table to modify
+  """
+  use Mix.Task
+
+  alias Mix.{Ecto, ExOauth2Provider, ExOauth2Provider.Migration}
+
+  @switches [table: :string]
+  @default_opts [table: "oauth_applications"]
+  @mix_task "ex_oauth2_provider.add_pkce_to_applications"
+
+  @template """
+  defmodule <%= inspect migration.repo %>.Migrations.AddOauthPkceToApplications do
+    use Ecto.Migration
+
+    def change do
+      alter table(:<%= migration.table %>) do
+        add :pkce, :string
+      end
+    end
+  end
+  """
+
+  @impl true
+  def run(args) do
+    ExOauth2Provider.no_umbrella!(@mix_task)
+
+    args
+    |> ExOauth2Provider.parse_options(@switches, @default_opts)
+    |> parse()
+    |> create_file(args)
+  end
+
+  defp parse({config, _parsed, _invalid}), do: config
+
+  defp create_file(config, args) do
+    args
+    |> Ecto.parse_repo()
+    |> Enum.map(&ensure_repo(&1, args))
+    |> Enum.map(&Map.put(config, :repo, &1))
+    |> Enum.each(&create_file/1)
+  end
+
+  defp create_file(%{repo: repo, table: table}) do
+    content =
+      EEx.eval_string(
+        @template,
+        migration: %{
+          repo: repo,
+          table: table
+        }
+      )
+
+    Migration.create_migration_file(repo, "AddOauthPkceToApplications", content)
+  end
+
+  defp ensure_repo(repo, args) do
+    Ecto.ensure_repo(repo, args ++ ~w(--no-deps-check))
+  end
+end

--- a/lib/mix/tasks/add_pkce_to_applications.ex
+++ b/lib/mix/tasks/add_pkce_to_applications.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.ExOauth2Provider.AddPkceToApplications do
 
     def change do
       alter table(:<%= migration.table %>) do
-        add :pkce, :string
+        add :pkce, :string, null: false, default: "disabled"
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExOauth2Provider.Mixfile do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "0.10.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExOauth2Provider.Mixfile do
   use Mix.Project
 
-  @version "0.5.6"
+  @version "1.0.0"
 
   def project do
     [

--- a/test/ex_oauth2_provider/access_grants/access_grant_test.exs
+++ b/test/ex_oauth2_provider/access_grants/access_grant_test.exs
@@ -8,7 +8,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
   alias ExOauth2Provider.Test.Fixtures
   alias ExOauth2Provider.Test.PKCE
 
-  describe "changeset/3" do
+  describe "changeset/4" do
     test "returns a valid changeset with a token and the default app scope when the attrs are valid" do
       app = Fixtures.application()
       user = Fixtures.resource_owner()
@@ -23,7 +23,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, otp_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert grant.application == app
@@ -48,7 +48,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, otp_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert grant.expires_in == 900
@@ -63,7 +63,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, otp_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert {"is invalid", _} = errors[:expires_in]
@@ -83,7 +83,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, opt_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert {"can't be blank", _} = errors[:redirect_uri]
@@ -98,7 +98,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, opt_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert {"can't be blank", _} = errors[:redirect_uri]
@@ -113,7 +113,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, opt_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert {"is invalid", _} = errors[:redirect_uri]
@@ -137,6 +137,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                    resource_owner: user
                  },
                  attrs,
+                 app,
                  otp_app: :ex_oauth2_provider
                )
                |> Changeset.put_change(:token, grant.token)
@@ -160,7 +161,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, opt_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert grant.scopes == "read write"
@@ -176,7 +177,7 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider)
+               |> AccessGrant.changeset(attrs, app, opt_app: :ex_oauth2_provider)
                |> Changeset.apply_action(:validate)
 
       assert {~s(not in permitted scopes list: "public read write"), _} = errors[:scopes]
@@ -198,7 +199,10 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider, pkce: :enabled)
+               |> AccessGrant.changeset(attrs, app,
+                 opt_app: :ex_oauth2_provider,
+                 pkce: :all_methods
+               )
                |> Changeset.apply_action(:validate)
 
       assert {"can't be blank", _} = errors[:code_challenge]
@@ -223,7 +227,10 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                    application: app,
                    resource_owner: user
                  }
-                 |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider, pkce: :enabled)
+                 |> AccessGrant.changeset(attrs, app,
+                   opt_app: :ex_oauth2_provider,
+                   pkce: :all_methods
+                 )
                  |> Changeset.apply_action(:validate)
 
         assert grant.code_challenge == challenge
@@ -247,7 +254,10 @@ defmodule ExOauth2Provider.AccessGrants.AccessGrantTest do
                  application: app,
                  resource_owner: user
                }
-               |> AccessGrant.changeset(attrs, otp_app: :ex_oauth2_provider, pkce: :enabled)
+               |> AccessGrant.changeset(attrs, app,
+                 opt_app: :ex_oauth2_provider,
+                 pkce: :all_methods
+               )
                |> Changeset.apply_action(:validate)
 
       refute Keyword.has_key?(errors, :code_challenge)

--- a/test/ex_oauth2_provider/access_grants/access_grants_test.exs
+++ b/test/ex_oauth2_provider/access_grants/access_grants_test.exs
@@ -129,7 +129,7 @@ defmodule ExOauth2Provider.AccessGrantsTest do
                  application,
                  attrs,
                  otp_app: :ex_oauth2_provider,
-                 pkce: :enabled
+                 pkce: :all_methods
                )
 
       assert grant.code_challenge == challenge
@@ -141,7 +141,7 @@ defmodule ExOauth2Provider.AccessGrantsTest do
                  application,
                  @valid_attrs,
                  otp_app: :ex_oauth2_provider,
-                 pkce: :enabled
+                 pkce: :all_methods
                )
 
       assert {"can't be blank", _} = changeset.errors[:code_challenge]

--- a/test/ex_oauth2_provider/config_test.exs
+++ b/test/ex_oauth2_provider/config_test.exs
@@ -30,38 +30,38 @@ defmodule ExOauth2Provider.ConfigTest do
     end
   end
 
-  describe "pkce_option/1" do
+  describe "pkce_setting/1" do
     test "returns :disabled by default" do
-      assert Config.pkce_option([]) == :disabled
+      assert Config.pkce_setting([]) == :disabled
     end
 
     test "returns the value from the given config when supported" do
-      for value <- [:disabled, :enabled, :plain_only, :s256_only] do
-        assert Config.pkce_option(pkce: value) == value
+      for value <- [:all_methods, :disabled, :plain_only, :s256_only] do
+        assert Config.pkce_setting(pkce: value) == value
       end
     end
 
     test "returns the value from the app config when supported" do
-      for value <- [:disabled, :enabled, :plain_only, :s256_only] do
+      for value <- [:all_methods, :disabled, :plain_only, :s256_only] do
         Application.put_env(:my_app, ExOauth2Provider, pkce: value)
 
-        assert Config.pkce_option(otp_app: :my_app) == value
+        assert Config.pkce_setting(otp_app: :my_app) == value
       end
     end
 
     test "raises an error when given an unsupported value" do
       assert_raise ArgumentError,
-                   "pkce must be one of :disabled | :enabled | :plain_only | :s256_only",
+                   "pkce must be one of all_methods | disabled | plain_only | s256_only",
                    fn ->
-                     assert Config.pkce_option(pkce: :foo)
+                     assert Config.pkce_setting(pkce: :foo)
                    end
 
       assert_raise ArgumentError,
-                   "pkce must be one of :disabled | :enabled | :plain_only | :s256_only",
+                   "pkce must be one of all_methods | disabled | plain_only | s256_only",
                    fn ->
                      Application.put_env(:my_app, ExOauth2Provider, pkce: :foo)
 
-                     assert Config.pkce_option(otp_app: :my_app)
+                     assert Config.pkce_setting(otp_app: :my_app)
                    end
     end
   end
@@ -69,14 +69,14 @@ defmodule ExOauth2Provider.ConfigTest do
   describe "use_pkce?/1" do
     test "returns true when the otp app is set to use_pkce" do
       config = [otp_app: :ex_oauth2_provider]
-      assert Config.use_pkce?(pkce: :enabled) == true
+      assert Config.use_pkce?(pkce: :all_methods) == true
       assert Config.use_pkce?(pkce: :plain_only) == true
       assert Config.use_pkce?(pkce: :s256_only) == true
       assert Config.use_pkce?(pkce: :disabled) == false
       assert Config.use_pkce?(config) == false
 
       # Verify it grabs from the app env
-      Application.put_env(:my_app, ExOauth2Provider, pkce: :enabled)
+      Application.put_env(:my_app, ExOauth2Provider, pkce: :all_methods)
       assert Config.use_pkce?(otp_app: :my_app) == true
 
       Application.put_env(:my_app, ExOauth2Provider, pkce: :disabled)

--- a/test/ex_oauth2_provider/oauth2/authorization_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization_test.exs
@@ -8,16 +8,24 @@ defmodule ExOauth2Provider.AuthorizationTest do
 
   @client_id "Jf5rM8hQBc"
   @client_secret "secret"
+
   @valid_request %{
     "client_id" => @client_id,
     "response_type" => "code",
     "scope" => "public read write"
   }
+
+  @access_denied %{
+    error: :access_denied,
+    error_description: "The resource owner or authorization server denied the request."
+  }
+
   @invalid_request %{
     error: :invalid_request,
     error_description:
       "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
   }
+
   @invalid_response_type %{
     error: :unsupported_response_type,
     error_description: "The authorization server does not support this response type."
@@ -113,8 +121,9 @@ defmodule ExOauth2Provider.AuthorizationTest do
                 "https://example.com/path?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+this+response+type.&param=1&state=40612"}
     end
 
-    test "supports the PKCE option", %{application: %{id: app_id}, resource_owner: owner} do
+    test "supports PKCE", %{application: %{id: app_id}, resource_owner: owner} do
       code_challenge = PKCE.generate_code_challenge()
+      config = [{:pkce, :all_methods} | @config]
 
       request =
         Map.merge(
@@ -126,11 +135,19 @@ defmodule ExOauth2Provider.AuthorizationTest do
         )
 
       assert {:ok, %OauthApplication{id: ^app_id}, ~w[public read write]} =
-               Authorization.preauthorize(
-                 owner,
-                 request,
-                 [{:with, :pkce} | @config]
-               )
+               Authorization.preauthorize(owner, request, config)
+
+      request =
+        Map.merge(
+          @valid_request,
+          %{
+            "code_challenge" => code_challenge,
+            "code_challenge_method" => "EXPLODE!!!"
+          }
+        )
+
+      assert {:error, %{error: :invalid_request}, _bad_request} =
+               Authorization.preauthorize(owner, request, config)
     end
   end
 
@@ -160,6 +177,7 @@ defmodule ExOauth2Provider.AuthorizationTest do
 
     test "supports the PKCE option", %{resource_owner: owner} do
       code_challenge = PKCE.generate_code_challenge()
+      config = [{:pkce, :all_methods} | @config]
 
       request =
         Map.merge(
@@ -170,12 +188,19 @@ defmodule ExOauth2Provider.AuthorizationTest do
           }
         )
 
-      {:native_redirect, %{code: _code}} =
-        Authorization.authorize(
-          owner,
-          request,
-          [{:with, :pkce} | @config]
+      {:native_redirect, %{code: _code}} = Authorization.authorize(owner, request, config)
+
+      request =
+        Map.merge(
+          @valid_request,
+          %{
+            "code_challenge" => code_challenge,
+            "code_challenge_method" => "FIRE!!!"
+          }
         )
+
+      {:error, %{error: :invalid_request}, _bad_request} =
+        Authorization.authorize(owner, request, config)
     end
   end
 
@@ -195,6 +220,11 @@ defmodule ExOauth2Provider.AuthorizationTest do
   end
 
   describe "deny/3" do
+    test "blocks the request when the request is valid", %{resource_owner: resource_owner} do
+      assert Authorization.deny(resource_owner, @valid_request, @config) ==
+               {:error, @access_denied, :unauthorized}
+    end
+
     test "returns error when missing response_type", %{resource_owner: resource_owner} do
       params = Map.delete(@valid_request, "response_type")
 
@@ -207,6 +237,35 @@ defmodule ExOauth2Provider.AuthorizationTest do
 
       assert Authorization.deny(resource_owner, params, @config) ==
                {:error, @invalid_response_type, :unprocessable_entity}
+    end
+
+    test "supports PKCE", %{resource_owner: resource_owner} do
+      code_challenge = PKCE.generate_code_challenge()
+      config = [{:pkce, :all_methods} | @config]
+
+      request =
+        Map.merge(
+          @valid_request,
+          %{
+            "code_challenge" => code_challenge,
+            "code_challenge_method" => "S256"
+          }
+        )
+
+      assert Authorization.deny(resource_owner, request, config) ==
+               {:error, @access_denied, :unauthorized}
+
+      request =
+        Map.merge(
+          @valid_request,
+          %{
+            "code_challenge" => code_challenge,
+            "code_challenge_method" => "WRONG!!!"
+          }
+        )
+
+      assert Authorization.deny(resource_owner, request, config) ==
+               {:error, @invalid_request, :bad_request}
     end
   end
 end

--- a/test/ex_oauth2_provider/oauth2/pkce_test.exs
+++ b/test/ex_oauth2_provider/oauth2/pkce_test.exs
@@ -1,7 +1,6 @@
 defmodule ExOauth2Provider.PKCETest do
   use ExUnit.Case, async: true
 
-  alias Dummy.OauthAccessGrants.OauthAccessGrant
   alias Dummy.OauthApplications.OauthApplication
   alias ExOauth2Provider.PKCE
   alias ExOauth2Provider.Test
@@ -231,8 +230,6 @@ defmodule ExOauth2Provider.PKCETest do
       assert PKCE.valid?(context, pkce: :all_methods) == true
       assert PKCE.valid?(context, pkce: :s256_only) == true
       assert PKCE.valid?(context, pkce: :plain_only) == false
-
-      challenge = Test.PKCE.generate_code_challenge(%{method: :plain})
 
       context =
         Test.Fixtures.token_request_context_with_pkce(

--- a/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code/request_params_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code/request_params_test.exs
@@ -3,66 +3,67 @@ defmodule ExOauth2Provider.Token.AuthorizationCode.RequestParamsTest do
 
   alias Dummy.OauthAccessGrants.OauthAccessGrant
   alias ExOauth2Provider.Token.AuthorizationCode.RequestParams
+  alias ExOauth2Provider.Test.Fixtures
   alias ExOauth2Provider.Test.PKCE
 
   describe "valid?/2" do
     test "returns true for valid params" do
-      assert RequestParams.valid?(
-               %{
-                 access_grant: %OauthAccessGrant{redirect_uri: "test"},
-                 request: %{"redirect_uri" => "test"}
-               },
-               []
-             ) == true
+      context =
+        Fixtures.token_request_context(
+          access_grant: %OauthAccessGrant{redirect_uri: "test"},
+          request: %{"redirect_uri" => "test"}
+        )
+
+      assert RequestParams.valid?(context, []) == true
     end
 
     test "returns true for valid params with PKCE" do
       verifier = PKCE.generate_code_verifier()
       challenge = PKCE.generate_code_challenge(verifier, :s256)
 
-      assert RequestParams.valid?(
-               %{
-                 access_grant: %OauthAccessGrant{
-                   code_challenge: challenge,
-                   code_challenge_method: :s256,
-                   redirect_uri: "test"
-                 },
-                 request: %{
-                   "code_verifier" => verifier,
-                   "redirect_uri" => "test"
-                 }
-               },
-               pkce: :enabled
-             ) == true
+      context =
+        Fixtures.token_request_context_with_pkce(
+          access_grant: %OauthAccessGrant{
+            code_challenge: challenge,
+            code_challenge_method: :s256,
+            redirect_uri: "test"
+          },
+          request: %{
+            "code_verifier" => verifier,
+            "redirect_uri" => "test"
+          }
+        )
+
+      assert RequestParams.valid?(context, pkce: :enabled) == true
     end
 
     test "returns false when redirect URI is invalid" do
-      assert RequestParams.valid?(
-               %{
-                 access_grant: %OauthAccessGrant{redirect_uri: "test"},
-                 request: %{"redirect_uri" => "different-one"}
-               },
-               []
-             ) == false
+      context =
+        Fixtures.token_request_context(
+          access_grant: %OauthAccessGrant{redirect_uri: "test"},
+          request: %{"redirect_uri" => "different-one"}
+        )
+
+      assert RequestParams.valid?(context, []) == false
     end
 
     test "returns false when PKCE is invalid" do
       verifier = PKCE.generate_code_verifier()
 
-      assert RequestParams.valid?(
-               %{
-                 access_grant: %OauthAccessGrant{
-                   code_challenge: "challenge",
-                   code_challenge_method: "S256",
-                   redirect_uri: "test"
-                 },
-                 request: %{
-                   "code_verifier" => verifier,
-                   "redirect_uri" => "test"
-                 }
-               },
-               pkce: :enabled
-             ) == false
+      context =
+        Fixtures.token_request_context_with_pkce(
+          access_grant: %OauthAccessGrant{
+            code_challenge: "challenge",
+            code_challenge_method: "S256",
+            redirect_uri: "test"
+          },
+          request: %{
+            "code_verifier" => verifier,
+            "redirect_uri" => "test"
+          }
+        )
+
+      assert RequestParams.valid?(context, pkce: :all_methods) == false
     end
 
     test "returns false when the context is unexpected" do

--- a/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token/strategy/authorization_code_test.exs
@@ -19,6 +19,7 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
   @client_secret "secret"
   @code "code"
   @redirect_uri "urn:ietf:wg:oauth:2.0:oob"
+
   @valid_request %{
     "client_id" => @client_id,
     "client_secret" => @client_secret,
@@ -210,7 +211,7 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
       |> Repo.update!()
 
       assert {:ok, %{access_token: _}} =
-               Token.grant(request, otp_app: :ex_oauth2_provider, pkce: :enabled)
+               Token.grant(request, otp_app: :ex_oauth2_provider, pkce: :all_methods)
     end
 
     test "returns an error when the PKCE info is invalid" do
@@ -218,7 +219,7 @@ defmodule ExOauth2Provider.Token.Strategy.AuthorizationCodeTest do
 
       request = Map.put(@valid_request, "code_verifier", verifier)
 
-      assert Token.grant(request, otp_app: :ex_oauth2_provider, pkce: :enabled) ==
+      assert Token.grant(request, otp_app: :ex_oauth2_provider, pkce: :all_methods) ==
                {:error, @invalid_grant, :unprocessable_entity}
     end
   end

--- a/test/ex_oauth2_provider/oauth2/token_test.exs
+++ b/test/ex_oauth2_provider/oauth2/token_test.exs
@@ -3,23 +3,154 @@ defmodule ExOauth2Provider.TokenTest do
 
   alias ExOauth2Provider.Token
   alias ExOauth2Provider.Test.Fixtures
+  alias ExOauth2Provider.Test.PKCE
 
-  @client_id          "Jf5rM8hQBc"
-  @client_secret      "secret"
+  @client_id "Jf5rM8hQBc"
+  @client_secret "secret"
 
-  setup do
-    application = Fixtures.application()
-    {:ok, %{application: application}}
+  describe "#grant/2" do
+    test "#returns an error when invalid grant_type" do
+      assert {
+               :error,
+               %{
+                 error: :unsupported_grant_type,
+                 error_description: description
+               },
+               :unprocessable_entity
+             } =
+               Token.grant(
+                 %{
+                   "client_id" => @client_id,
+                   "client_secret" => @client_secret,
+                   "grant_type" => "invalid"
+                 },
+                 otp_app: :ex_oauth2_provider
+               )
+
+      assert description =~ ~r/grant type is not supported/i
+    end
+
+    test "#returns an error when grant_type is missing" do
+      assert {
+               :error,
+               %{
+                 error: :invalid_request,
+                 error_description: description
+               },
+               :bad_request
+             } =
+               Token.grant(
+                 %{
+                   "client_id" => @client_id,
+                   "client_secret" => @client_secret
+                 },
+                 otp_app: :ex_oauth2_provider
+               )
+
+      assert description =~ ~r/the request is missing a required/i
+    end
   end
 
-  test "#grant/2 error when invalid grant_type" do
-    request_invalid_grant_type = Map.merge(%{"client_id" => @client_id,
-                                             "client_secret" => @client_secret,
-                                             "grant_type" => "client_credentials"},
-                                           %{"grant_type" => "invalid"})
-    expected_error = %{error: :unsupported_grant_type,
-                       error_description: "The authorization grant type is not supported by the authorization server."}
+  describe "#grant/2 when grant_type is authorization_code" do
+    test "returns the response of AuthorizationCode.grant/2 when valid" do
+      application = Fixtures.application()
+      user = Fixtures.resource_owner()
 
-    assert Token.grant(request_invalid_grant_type, otp_app: :ex_oauth2_provider) == {:error, expected_error, :unprocessable_entity}
+      Fixtures.access_grant(
+        application,
+        user,
+        "ima-token",
+        application.redirect_uri
+      )
+
+      assert {
+               :ok,
+               %{
+                 access_token: _,
+                 created_at: _,
+                 expires_in: _,
+                 refresh_token: _,
+                 scope: "read",
+                 token_type: "bearer"
+               }
+             } =
+               Token.grant(
+                 %{
+                   "client_id" => application.uid,
+                   "client_secret" => application.secret,
+                   "code" => "ima-token",
+                   "grant_type" => "authorization_code",
+                   "redirect_uri" => application.redirect_uri
+                 },
+                 otp_app: :ex_oauth2_provider
+               )
+    end
+
+    test "returns validation errors that AuthorizationCode.grant/2 returns" do
+      application = Fixtures.application()
+
+      assert {:error, %{error: :invalid_grant}, :unprocessable_entity} =
+               Token.grant(
+                 %{
+                   "client_id" => application.uid,
+                   "client_secret" => application.secret,
+                   "code" => "ima-token",
+                   "grant_type" => "authorization_code",
+                   "redirect_uri" => application.redirect_uri
+                 },
+                 otp_app: :ex_oauth2_provider
+               )
+    end
+
+    test "supports PKCE" do
+      verifier = PKCE.generate_code_verifier()
+      challenge = PKCE.generate_code_challenge(verifier, :s256)
+      application = Fixtures.application()
+      user = Fixtures.resource_owner()
+
+      config = [
+        otp_app: :ex_oauth2_provider,
+        pkce: :all_methods
+      ]
+
+      Fixtures.access_grant(
+        application,
+        user,
+        "ima-token",
+        application.redirect_uri,
+        code_challenge: challenge,
+        code_challenge_method: :s256
+      )
+
+      payload = %{
+        "client_id" => application.uid,
+        "client_secret" => application.secret,
+        "code" => "ima-token",
+        "code_verifier" => verifier,
+        "grant_type" => "authorization_code",
+        "redirect_uri" => application.redirect_uri
+      }
+
+      assert {:ok, _access_token} = Token.grant(payload, config)
+
+      # Insert another grant that's not revoked so we can test again with bad PKCE data.
+      Fixtures.access_grant(
+        application,
+        user,
+        "ima-different-token",
+        application.redirect_uri,
+        code_challenge: challenge,
+        code_challenge_method: :s256
+      )
+
+      # RFC states invalid grant error must be returned on bad PKCE challenge
+      assert {:error, %{error: :invalid_grant}, :unprocessable_entity} =
+               payload
+               |> Map.merge(%{
+                 "code" => "ima-different-token",
+                 "code_verifier" => "bad-verifier"
+               })
+               |> Token.grant(config)
+    end
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,7 +1,10 @@
 defmodule ExOauth2Provider.Test.Fixtures do
   @moduledoc false
 
-  alias ExOauth2Provider.AccessTokens
+  alias ExOauth2Provider.{
+    AccessTokens,
+    Test.PKCE
+  }
 
   alias Dummy.{
     OauthApplications.OauthApplication,
@@ -12,6 +15,11 @@ defmodule ExOauth2Provider.Test.Fixtures do
   }
 
   alias Ecto.Changeset
+
+  @code_challenge_request_param_lookup %{
+    plain: "plain",
+    s256: "S256"
+  }
 
   def resource_owner(attrs \\ []) do
     attrs = Keyword.merge([email: "foo@example.com"], attrs)
@@ -57,7 +65,9 @@ defmodule ExOauth2Provider.Test.Fixtures do
       attrs
       |> Keyword.get(:application)
       |> Kernel.||(application())
-      |> AccessTokens.create_application_token(Enum.into(attrs, %{}), otp_app: :ex_oauth2_provider)
+      |> AccessTokens.create_application_token(Enum.into(attrs, %{}),
+        otp_app: :ex_oauth2_provider
+      )
 
     access_token
   end
@@ -90,5 +100,145 @@ defmodule ExOauth2Provider.Test.Fixtures do
     %OauthDeviceGrant{}
     |> Changeset.change(attrs)
     |> Repo.insert!()
+  end
+
+  @doc """
+  Veeeeeery basic. Override as needed. There is a default client and request
+  but anything else you provide in is merged. So if you pass `:foo` then it'll
+  be included. The default is a request with PKCE disabled and no PKCE info.
+
+  ## Opts
+
+  - `:client` - The OauthApplication to use.
+  - `:request` - The request params
+  - `:resource_owner` - The resource owner that made the request.
+  """
+  @spec authorization_request_context(opts :: list()) :: map()
+  def authorization_request_context(opts \\ []) do
+    opts = Map.new(opts)
+
+    Map.merge(
+      %{
+        client: %OauthApplication{pkce: :disabled},
+        request: %{},
+        resource_owner: %{}
+      },
+      opts
+    )
+  end
+
+  @doc """
+  Generate an auth context with PKCE. Works the same as authorization_request_context/1
+  except it also supports the options below. It's important to note that the PKCE request
+  params are generated and provided so if you want something more custom you must pass in
+  `:request` with what you want.
+
+  ## Options
+
+  - `:app_setting` - The pkce setting for the app. Default `:all_methods`
+  - `:client` - Override the OauthApplication.
+  - `:code_challenge` - The code challenge for the request param. Default is a generated
+                        one that relies on the challenge method value `:code_challenge_method` option.
+  - `:code_challenge_method` - The code chalenge method to use. Default is `:s256` but can also be `:plain`.
+  - `:code_challenge_method_request_param` - The value to use for the request param for the code challenge
+                                             method. Default is to convert the value of
+                                             `:code_challenge_method`
+  - `:request` - A custom request to use. When specified it'll override the generated one.
+  """
+  def authorization_request_context_with_pkce(opts \\ []) do
+    {app_setting, opts} = Keyword.pop(opts, :app_setting, :all_methods)
+    {challenge_method, opts} = Keyword.pop(opts, :code_challenge_method, :s256)
+
+    {challenge, opts} =
+      Keyword.pop(
+        opts,
+        :code_challenge,
+        PKCE.generate_code_challenge(%{method: challenge_method})
+      )
+
+    {param, opts} =
+      Keyword.pop(
+        opts,
+        :code_challenge_method_request_param,
+        @code_challenge_request_param_lookup[challenge_method]
+      )
+
+    {request, opts} =
+      Keyword.pop(
+        opts,
+        :request,
+        %{
+          "code_challenge" => challenge,
+          "code_challenge_method" => param
+        }
+      )
+
+    {client, opts} = Keyword.pop(opts, :client, %OauthApplication{pkce: app_setting})
+
+    opts
+    |> Keyword.merge(client: client, request: request)
+    |> authorization_request_context()
+  end
+
+  @doc """
+  Veeeeeery basic. Override as needed. There is a default client and request
+  but anything else you provide in is merged. So if you pass `:foo` then it'll
+  be included. The default is a request with PKCE disabled and no PKCE info.
+
+  ## Opts
+
+  - `:client` - The OauthApplication to use.
+  - `:request` - The request params
+  - `:resource_owner` - The resource owner that made the request.
+  """
+  @spec token_request_context(opts :: list()) :: map()
+  def token_request_context(opts \\ []) do
+    opts = Map.new(opts)
+
+    Map.merge(
+      %{
+        access_grant: %OauthAccessGrant{},
+        client: %OauthApplication{pkce: :disabled},
+        request: %{},
+        resource_owner: %User{}
+      },
+      opts
+    )
+  end
+
+  @doc """
+  Generate a token request context with PKCE fields. This is the same as
+  token_request_context/1 but with additional options supported.
+
+  ## Options
+
+  - `:app_setting` - The app's pkce setting.
+  - `:client` - The app's pkce setting.
+  - `:code_challenge` - The code challenge for the access grant.
+                        one that relies on the challenge method value `:code_challenge_method` option.
+  - `:code_challenge_method` - The code chalenge method to use. Default is `:s256` but can also be `:plain`.
+  - `:code_verifier` - The verifier to use in the validation.
+  - `:request` - A custom request param map to pass if you wish to do something else.
+  """
+  def token_request_context_with_pkce(opts \\ []) do
+    {app_setting, opts} = Keyword.pop(opts, :app_setting, :all_methods)
+    {client, opts} = Keyword.pop(opts, :client, %OauthApplication{pkce: app_setting})
+    {method, opts} = Keyword.pop(opts, :code_challenge_method, :s256)
+    {verifier, opts} = Keyword.pop(opts, :code_verifier, PKCE.generate_code_verifier())
+
+    {challenge, opts} =
+      Keyword.pop(opts, :code_challenge, PKCE.generate_code_challenge(verifier, method))
+
+    {request, opts} = Keyword.pop(opts, :request, %{"code_verifier" => verifier})
+
+    {grant, opts} =
+      Keyword.pop(opts, :access_grant, %OauthAccessGrant{
+        code_challenge: challenge,
+        code_challenge_method: method
+      })
+
+    opts
+    |> Keyword.merge(access_grant: grant, client: client, request: request)
+    |> token_request_context()
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -35,12 +35,12 @@ defmodule ExOauth2Provider.Test.Fixtures do
 
     attrs =
       [
-        owner_id: resource_owner.id,
-        uid: "test",
-        secret: "secret",
         name: "OAuth Application",
+        owner_id: resource_owner.id,
         redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
-        scopes: "public read write"
+        scopes: "public read write",
+        secret: "secret",
+        uid: "test"
       ]
       |> Keyword.merge(attrs)
       |> Keyword.drop([:resource_owner])
@@ -72,16 +72,20 @@ defmodule ExOauth2Provider.Test.Fixtures do
     access_token
   end
 
-  def access_grant(application, user, code, redirect_uri) do
-    attrs = [
-      expires_in: 900,
-      redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
-      application_id: application.id,
-      resource_owner_id: user.id,
-      token: code,
-      scopes: "read",
-      redirect_uri: redirect_uri
-    ]
+  def access_grant(application, user, code, redirect_uri, overrides \\ []) do
+    attrs =
+      Keyword.merge(
+        [
+          expires_in: 900,
+          redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+          application_id: application.id,
+          resource_owner_id: user.id,
+          token: code,
+          scopes: "read",
+          redirect_uri: redirect_uri
+        ],
+        overrides
+      )
 
     %OauthAccessGrant{}
     |> Changeset.change(attrs)


### PR DESCRIPTION
This implements the ability to set the PKCE setting for each oauth app separate from configuration. 

This takes priority over configuration and works as follows:

1) The client pkce value is checked and if enabled - relied upon.
2) If :disabled - then the passed config is checked, if enabled, used.
3) The config is checked based on the otp app option specified as a last resort.

This allows tremendous flexibility with PKCE usage.
